### PR TITLE
Implement alignment specifiers in templates, fixes #7

### DIFF
--- a/src/Serilog.Expressions/Templates/Ast/FormattedExpression.cs
+++ b/src/Serilog.Expressions/Templates/Ast/FormattedExpression.cs
@@ -1,5 +1,6 @@
 using System;
 using Serilog.Expressions.Ast;
+using Serilog.Parsing;
 
 namespace Serilog.Templates.Ast
 {
@@ -7,11 +8,13 @@ namespace Serilog.Templates.Ast
     {
         public Expression Expression { get; }
         public string? Format { get; }
+        public Alignment? Alignment { get; }
 
-        public FormattedExpression(Expression expression, string? format)
+        public FormattedExpression(Expression expression, string? format, Alignment? alignment)
         {
             Expression = expression ?? throw new ArgumentNullException(nameof(expression));
             Format = format;
+            Alignment = alignment;
         }
     }
 }

--- a/src/Serilog.Expressions/Templates/Compilation/TemplateCompiler.cs
+++ b/src/Serilog.Expressions/Templates/Compilation/TemplateCompiler.cs
@@ -15,7 +15,7 @@ namespace Serilog.Templates.Compilation
             {
                 LiteralText text => new CompiledLiteralText(text.Text),
                 FormattedExpression expression => new CompiledFormattedExpression(
-                    ExpressionCompiler.Compile(expression.Expression, nameResolver), expression.Format),
+                    ExpressionCompiler.Compile(expression.Expression, nameResolver), expression.Format, expression.Alignment),
                 TemplateBlock block => new CompiledTemplateBlock(block.Elements.Select(e => Compile(e, nameResolver)).ToArray()),
                 _ => throw new NotSupportedException()
             };

--- a/src/Serilog.Expressions/Templates/Rendering/LevelRenderer.cs
+++ b/src/Serilog.Expressions/Templates/Rendering/LevelRenderer.cs
@@ -14,6 +14,8 @@
 
 using Serilog.Events;
 
+// ReSharper disable StringLiteralTypo
+
 namespace Serilog.Templates.Rendering
 {
     /// <summary>

--- a/src/Serilog.Expressions/Templates/Rendering/Padding.cs
+++ b/src/Serilog.Expressions/Templates/Rendering/Padding.cs
@@ -1,0 +1,54 @@
+﻿// Copyright 2013-2020 Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.IO;
+using System.Linq;
+using Serilog.Parsing;
+
+namespace Serilog.Templates.Rendering
+{
+    static class Padding
+    {
+        static readonly char[] PaddingChars = Enumerable.Repeat(' ', 80).ToArray();
+
+        /// <summary>
+        /// Writes the provided value to the output, applying direction-based padding when <paramref name="alignment"/> is provided.
+        /// </summary>
+        public static void Apply(TextWriter output, string value, Alignment alignment)
+        {
+            if (value.Length >= alignment.Width)
+            {
+                output.Write(value);
+                return;
+            }
+
+            var pad = alignment.Width - value.Length;
+
+            if (alignment.Direction == AlignmentDirection.Left)
+                output.Write(value);
+
+            if (pad <= PaddingChars.Length)
+            {
+                output.Write(PaddingChars, 0, pad);
+            }
+            else
+            {
+                output.Write(new string(' ', pad));
+            }
+
+            if (alignment.Direction == AlignmentDirection.Right)
+                output.Write(value);
+        }
+    }
+}

--- a/test/Serilog.Expressions.Tests/Cases/template-evaluation-cases.asv
+++ b/test/Serilog.Expressions.Tests/Cases/template-evaluation-cases.asv
@@ -9,4 +9,7 @@ Text only                                ⇶ Text only
 {{ Escaped {{ left {{                    ⇶ { Escaped { left {
 }} Escaped }} right }}                   ⇶ } Escaped } right }
 Formatted {42:0000}                      ⇶ Formatted 0042
+Aligned {42,4}!                          ⇶ Aligned   42!
+Left {42,-4}!                            ⇶ Left 42  !
+Under width {42,0}!                      ⇶ Under width 42!
 {@m}                                     ⇶ Hello, nblumhardt!

--- a/test/Serilog.Expressions.Tests/TemplateParserTests.cs
+++ b/test/Serilog.Expressions.Tests/TemplateParserTests.cs
@@ -12,6 +12,9 @@ namespace Serilog.Expressions.Tests
         [InlineData("Unclosed {hole", "Un-closed hole, `}` expected.")]
         [InlineData("Syntax {+Err}or", "Invalid expression, unexpected operator `+`, expected expression.")]
         [InlineData("Syntax {1 + 2 and}or", "Invalid expression, unexpected `}`, expected expression.")]
+        [InlineData("Missing {Align,-} digits", "Incomplete alignment specifier, expected digits.")]
+        [InlineData("Non-digit {Align,x} specifier", "Invalid alignment specifier, expected digits.")]
+        [InlineData("Empty {Align,} digits", "Incomplete alignment specifier, expected width.")]
         public void ErrorsAreReported(string input, string error)
         {
             Assert.False(ExpressionTemplate.TryParse(input, null, null, out _, out var actual));


### PR DESCRIPTION
Based on serilog/serilog, so should behave very similarly to message templates/output templates.