### PR TITLE
Test templates by comparing output with existing formatters

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,12 +95,12 @@ Log.Logger = new LoggerConfiguration()
 
 Note the use of `{Items[0]}`: "holes" in expression templates can include any valid expression.
 
-Newline-delimited JSON (for example, emulating the [CLEF format](https://github.com/serilog/serilog-formatting-compact)) can be generated
+Newline-delimited JSON (for example, replicating the [CLEF format](https://github.com/serilog/serilog-formatting-compact)) can be generated
 using object literals:
 
 ```csharp
     .WriteTo.Console(new ExpressionTemplate(
-        "{ {@t, @mt, @l: if @l = 'Information' then undefined() else @l, @x, ..@p} }\n"))
+        "{ {@t, @mt, @r, @l: if @l = 'Information' then undefined() else @l, @x, ..@p} }\n"))
 ```
 
 ## Language reference
@@ -116,6 +116,10 @@ The following properties are available in expressions:
  * `@l` - the event's level, as a `LogEventLevel`
  * `@x` - the exception associated with the event, if any, as an `Exception`
  * `@p` - a dictionary containing all first-class properties; this supports properties with non-identifier names, for example `@p['snake-case-name']`
+ * `@i` - event id; a 32-bit numeric hash of the event's message template
+ * `@r` - renderings; if any tokens in the message template include .NET-specific formatting, an array of rendered values for each such token
+
+The built-in properties mirror those available in the CLEF format.
 
 ### Literals
 
@@ -175,12 +179,15 @@ calling a function will be undefined if:
 | `IsDefined(x)` | Returns `true` if the expression `x` has a value, including `null`, or `false` if `x` is undefined. |
 | `LastIndexOf(s, t)` | Returns the last index of substring `t` in string `s`, or -1 if the substring does not appear. |
 | `Length(x)` | Returns the length of a string or array. |
+| `Now()` | Returns `DateTimeOffset.Now`. |
 | `Round(n, m)` | Round the number `n` to `m` decimal places. |
 | `StartsWith(s, t)` | Tests whether the string `s` starts with substring `t`. |
 | `Substring(s, start, [length])` | Return the substring of string `s` from `start` to the end of the string, or of `length` characters, if this argument is supplied. |
 | `TagOf(o)` | Returns the `TypeTag` field of a captured object (i.e. where `TypeOf(x)` is `'object'`). |
+| `ToString(x, f)` | Applies the format string `f` to the formattable value `x`. |
 | `TypeOf(x)` | Returns a string describing the type of expression `x`: a .NET type name if `x` is scalar and non-null, or, `'array'`, `'object'`, `'dictionary'`, `'null'`, or `'undefined'`. |
 | `Undefined()` | Explicitly mark an undefined value. |
+| `UtcDateTime(x)` | Convert a `DateTime` or `DateTimeOffset` into a UTC `DateTime`. |
 
 Functions that compare text accept an optional postfix `ci` modifier to select case-insensitive comparisons:
 

--- a/src/Serilog.Expressions/Expressions/BuiltInProperty.cs
+++ b/src/Serilog.Expressions/Expressions/BuiltInProperty.cs
@@ -1,5 +1,20 @@
+// Copyright © Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 namespace Serilog.Expressions
 {
+    // See https://github.com/serilog/serilog-formatting-compact#reified-properties
     static class BuiltInProperty
     {
         public const string Exception = "x";
@@ -8,5 +23,7 @@ namespace Serilog.Expressions
         public const string Message = "m";
         public const string MessageTemplate = "mt";
         public const string Properties = "p";
+        public const string Renderings = "r";
+        public const string EventId = "i";
     }
 }

--- a/src/Serilog.Expressions/Expressions/Compilation/Linq/EventIdHash.cs
+++ b/src/Serilog.Expressions/Expressions/Compilation/Linq/EventIdHash.cs
@@ -1,0 +1,55 @@
+﻿// Copyright © Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+
+// ReSharper disable ForCanBeConvertedToForeach
+
+namespace Serilog.Expressions.Compilation.Linq
+{
+    /// <summary>
+    /// Hash functions for message templates. See <see cref="Compute"/>.
+    /// </summary>
+    public static class EventIdHash
+    {
+        /// <summary>
+        /// Compute a 32-bit hash of the provided <paramref name="messageTemplate"/>. The
+        /// resulting hash value can be uses as an event id in lieu of transmitting the
+        /// full template string.
+        /// </summary>
+        /// <param name="messageTemplate">A message template.</param>
+        /// <returns>A 32-bit hash of the template.</returns>
+        [CLSCompliant(false)]
+        public static uint Compute(string messageTemplate)
+        {
+            if (messageTemplate == null) throw new ArgumentNullException(nameof(messageTemplate));
+
+            // Jenkins one-at-a-time https://en.wikipedia.org/wiki/Jenkins_hash_function
+            unchecked
+            {
+                uint hash = 0;
+                for (var i = 0; i < messageTemplate.Length; ++i)
+                {
+                    hash += messageTemplate[i];
+                    hash += hash << 10;
+                    hash ^= hash >> 6;
+                }
+                hash += hash << 3;
+                hash ^= hash >> 11;
+                hash += hash << 15;
+                return hash;
+            }
+        }
+    }
+}

--- a/src/Serilog.Expressions/Expressions/Operators.cs
+++ b/src/Serilog.Expressions/Expressions/Operators.cs
@@ -24,12 +24,15 @@ namespace Serilog.Expressions
         public const string OpIsDefined = "IsDefined";
         public const string OpLastIndexOf = "LastIndexOf";
         public const string OpLength = "Length";
+        public const string OpNow = "Now";
         public const string OpRound = "Round";
         public const string OpStartsWith = "StartsWith";
         public const string OpSubstring = "Substring";
         public const string OpTagOf = "TagOf";
+        public const string OpToString = "ToString";
         public const string OpTypeOf = "TypeOf";
         public const string OpUndefined = "Undefined";
+        public const string OpUtcDateTime = "UtcDateTime";
 
         public const string IntermediateOpLike = "_Internal_Like";
         public const string IntermediateOpNotLike = "_Internal_NotLike";

--- a/src/Serilog.Expressions/Expressions/Runtime/RuntimeOperators.cs
+++ b/src/Serilog.Expressions/Expressions/Runtime/RuntimeOperators.cs
@@ -467,5 +467,38 @@ namespace Serilog.Expressions.Runtime
         {
             return Coerce.IsTrue(condition) ? consequent : alternative;
         }
+
+        public static LogEventPropertyValue? ToString(LogEventPropertyValue? value, LogEventPropertyValue? format)
+        {
+            if (!(value is ScalarValue sv && sv.Value is IFormattable formattable) ||
+                !Coerce.String(format, out var fmt))
+            {
+                return null;
+            }
+
+            // TODO #19: formatting is culture-specific.
+            return new ScalarValue(formattable.ToString(fmt, null));
+        }
+        
+        public static LogEventPropertyValue? UtcDateTime(LogEventPropertyValue? dateTime)
+        {
+            if (dateTime is ScalarValue sv)
+            {
+                if (sv.Value is DateTimeOffset dto)
+                    return new ScalarValue(dto.UtcDateTime);
+                
+                if (sv.Value is DateTime dt)
+                    return new ScalarValue(dt.ToUniversalTime());
+            }
+
+            return null;
+        }
+        
+        // ReSharper disable once UnusedMember.Global
+        public static LogEventPropertyValue? Now()
+        {
+            // DateTimeOffset.Now is the generator for LogEvent.Timestamp.
+            return new ScalarValue(DateTimeOffset.Now);
+        }
     }
 }

--- a/src/Serilog.Expressions/Serilog.Expressions.csproj
+++ b/src/Serilog.Expressions/Serilog.Expressions.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>An embeddable mini-language for filtering, enriching, and formatting Serilog
       events, ideal for use with JSON or XML configuration.</Description>
-    <VersionPrefix>1.0.1</VersionPrefix>
+    <VersionPrefix>1.1.0</VersionPrefix>
     <Authors>Serilog Contributors</Authors>
     <TargetFramework>netstandard2.1</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/test/Serilog.Expressions.Tests/Cases/expression-evaluation-cases.asv
+++ b/test/Serilog.Expressions.Tests/Cases/expression-evaluation-cases.asv
@@ -217,7 +217,13 @@ if undefined() then 1 else 2         ⇶ 2
 if 'string' then 1 else 2            ⇶ 2
 if true then if false then 1 else 2 else 3 ⇶ 2
 
-// Typeof
+// ToString
+tostring(16, '000')                  ⇶ '016'
+tostring('test', '000')              ⇶ undefined()
+tostring(16, undefined())            ⇶ undefined()
+tostring(16, null)                   ⇶ undefined()
+
+// TypeOf
 typeof(undefined())                  ⇶ 'undefined'
 typeof('test')                       ⇶ 'System.String'
 typeof(10)                           ⇶ 'System.Decimal'
@@ -225,6 +231,9 @@ typeof(true)                         ⇶ 'System.Boolean'
 typeof(null)                         ⇶ 'null'
 typeof([])                           ⇶ 'array'
 typeof({})                           ⇶ 'object'
+
+// UtcDateTime
+tostring(utcdatetime(now()), 'o') like '20%' ⇶ true
 
 // Case comparison
 'test' = 'TEST'                      ⇶ false

--- a/test/Serilog.Expressions.Tests/FormatParityTests.cs
+++ b/test/Serilog.Expressions.Tests/FormatParityTests.cs
@@ -1,0 +1,173 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Serilog.Events;
+using Serilog.Expressions.Tests.Support;
+using Serilog.Formatting;
+using Serilog.Formatting.Compact;
+using Serilog.Formatting.Json;
+using Serilog.Parsing;
+using Serilog.Templates;
+using Xunit;
+
+namespace Serilog.Expressions.Tests
+{
+    /// <summary>
+    /// These tests track the ability of Serilog.Expressions to faithfully reproduce the JSON formats implemented in
+    /// Serilog and Serilog.Formatting.Compact. The tests jump through a few hoops to achieve byte-for-byte correctness;
+    /// in practice, valid JSON in these formats can be constructed with simpler templates.
+    /// </summary>
+    public class FormatParityTests
+    {
+        // Implements CLEF-style `@@` escaping of property names that begin with `@`.
+        // ReSharper disable once UnusedMember.Global
+        public static LogEventPropertyValue? ClefEscape(LogEventPropertyValue? logEventProperties)
+        {
+            if (!(logEventProperties is StructureValue st))
+                return null;
+
+            foreach (var check in st.Properties)
+            {
+                if (check.Name.Length > 0 && check.Name[0] == '@')
+                {
+                    var properties = new List<LogEventProperty>();
+
+                    foreach (var member in st.Properties)
+                    {
+                        var property = new LogEventProperty(
+                            member.Name.Length > 0 && member.Name[0] == '@' ? "@" + member.Name : member.Name,
+                            member.Value);
+                        
+                        properties.Add(property);
+                    }
+                    
+                    return new StructureValue(properties, st.TypeTag);
+                }
+            }
+
+            return logEventProperties;
+        }
+
+        // Renders a message template with old-style "quoted" strings (expression templates use the newer :lj formatting always).
+        // ReSharper disable once UnusedMember.Global
+        public static LogEventPropertyValue? ClassicRender(LogEventPropertyValue? messageTemplate, LogEventPropertyValue? properties)
+        {
+            if (!(messageTemplate is ScalarValue svt && svt.Value is string smt) ||
+                !(properties is StructureValue stp))
+            {
+                return null;
+            }
+            
+            var mt = new MessageTemplateParser().Parse(smt);
+            var space = new StringWriter();
+            mt.Render(stp.Properties.ToDictionary(p => p.Name, p => p.Value), space);
+            return new ScalarValue(space.ToString());
+        }
+
+        // Constructs the Renderings property used in the old JSON format.
+        // ReSharper disable once UnusedMember.Global
+        public static LogEventPropertyValue? ClassicRenderings(LogEventPropertyValue? messageTemplate, LogEventPropertyValue? properties)
+        {
+            if (!(messageTemplate is ScalarValue svt && svt.Value is string smt) ||
+                !(properties is StructureValue stp))
+            {
+                return null;
+            }
+            
+            var mt = new MessageTemplateParser().Parse(smt);
+            var tokensWithFormat = mt.Tokens
+                .OfType<PropertyToken>()
+                .Where(pt => pt.Format != null)
+                .GroupBy(pt => pt.PropertyName);
+
+            // ReSharper disable once PossibleMultipleEnumeration
+            if (!tokensWithFormat.Any())
+                return null;
+
+            var propertiesByName = stp.Properties.ToDictionary(p => p.Name, p => p.Value);
+
+            var renderings = new List<LogEventProperty>();
+            // ReSharper disable once PossibleMultipleEnumeration
+            foreach (var propertyFormats in tokensWithFormat)
+            {
+                var values = new List<LogEventPropertyValue>();
+
+                foreach (var format in propertyFormats)
+                {
+                    var sw = new StringWriter();
+                    
+                    format.Render(propertiesByName, sw);
+
+                    values.Add(new StructureValue(new []
+                    {
+                        new LogEventProperty("Format", new ScalarValue(format.Format)),
+                        new LogEventProperty("Rendering", new ScalarValue(sw.ToString())), 
+                    }));
+                }
+                
+                renderings.Add(new LogEventProperty(propertyFormats.Key, new SequenceValue(values)));
+            }
+            
+            return new StructureValue(renderings);
+        }        
+        
+        readonly ITextFormatter
+            _clef = new CompactJsonFormatter(),
+            _renderedClef = new RenderedCompactJsonFormatter(),
+            _classic = new JsonFormatter(),
+            _clefExpression = new ExpressionTemplate(
+                "{ {@t: UtcDateTime(@t), @mt, @r, @l: if @l = 'Information' then undefined() else @l, @x, ..ClefEscape(@p)} }" + Environment.NewLine,
+                null, new StaticMemberNameResolver(typeof(FormatParityTests))),
+            _renderedClefExpression = new ExpressionTemplate(
+                "{ {@t: UtcDateTime(@t), @m: ClassicRender(@mt, @p), @i: ToString(@i, 'x8'), @l: if @l = 'Information' then undefined() else @l, @x, ..ClefEscape(@p)} }" + Environment.NewLine,
+                null, new StaticMemberNameResolver(typeof(FormatParityTests))),
+            _classicExpression = new ExpressionTemplate(
+                "{ {Timestamp: @t, Level: @l, MessageTemplate: @mt, Exception: @x, Properties: if IsDefined(@p[?]) then @p else undefined(), Renderings: ClassicRenderings(@mt, @p)} }" + Environment.NewLine,
+                null, new StaticMemberNameResolver(typeof(FormatParityTests)));
+
+        static string Render(
+            ITextFormatter formatter,
+            LogEvent logEvent)
+        {
+            var space = new StringWriter();
+            formatter.Format(logEvent, space);
+            return space.ToString();
+        }
+        
+        void AssertWriteParity(
+            LogEventLevel level,
+            Exception? exception,
+            string messageTemplate,
+            params object[] propertyValues)
+        {
+            var sink = new CollectingSink();
+            using (var log = new LoggerConfiguration()
+                .MinimumLevel.Is(LevelAlias.Minimum)
+                .WriteTo.Sink(sink)
+                .CreateLogger())
+            {
+                log.Write(level, exception, messageTemplate, propertyValues);
+            }
+                
+            var clef = Render(_clef, sink.SingleEvent);
+            var clefExpression = Render(_clefExpression, sink.SingleEvent);
+            Assert.Equal(clef, clefExpression);
+            
+            var renderedClef = Render(_renderedClef, sink.SingleEvent);
+            var renderedClefExpression = Render(_renderedClefExpression, sink.SingleEvent);
+            Assert.Equal(renderedClef, renderedClefExpression);   
+            
+            var renderedClassic = Render(_classic, sink.SingleEvent);
+            var renderedClassicExpression = Render(_classicExpression, sink.SingleEvent);
+            Assert.Equal(renderedClassic, renderedClassicExpression);
+        }
+
+        [Fact]
+        public void ParityIsMaintained()
+        {
+            AssertWriteParity(LogEventLevel.Information, null, "Hello, world!");
+            AssertWriteParity(LogEventLevel.Debug, new Exception(), "Hello, {Name}, {Number:000}, {Another:#.00}", "world", 42, 3.1);
+        }
+    }
+}

--- a/test/Serilog.Expressions.Tests/Serilog.Expressions.Tests.csproj
+++ b/test/Serilog.Expressions.Tests/Serilog.Expressions.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyOriginatorKeyFile>../../assets/Serilog.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
@@ -12,6 +12,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="Serilog.Formatting.Compact" Version="1.1.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../../src/Serilog.Expressions/Serilog.Expressions.csproj" />


### PR DESCRIPTION
I'm frequently pointing people to this library as a means to customize JSON output, with `CompactJsonFormatter`, `RenderedCompactJsonFormatter`, or `JsonFormatter` as the starting point.

This PR adds a test that attempts to replicate these formats byte-for-byte, so that we can identify gaps and inconsistencies.

Along the way:

 * Added `@i` and `@r` properties that mirror the [CLEF built-ins with those names](https://github.com/serilog/serilog-formatting-compact#reified-properties) 
 * Added `UtcDateTime(d)`, `Now()`, `ToString(x, f)` (fixes #18)
 * Fixed wildcard comprehensions with unary conditions - `IsDefined(@p[?])` now works as expected (any property is defined :-))
 * Spotted some instances of #19 and added comments
 * Re-targeted tests to `net5.0`
 * Bumped version to 1.1
 