### PR TITLE
Fix wildcard semantics; fix like clause anchoring

### DIFF
--- a/src/Serilog.Expressions/Expressions/Ast/Expression.cs
+++ b/src/Serilog.Expressions/Expressions/Ast/Expression.cs
@@ -2,5 +2,7 @@
 {
     abstract class Expression
     {
+        // Used only as an enabler for testing and debugging.
+        public abstract override string ToString();
     }
 }

--- a/src/Serilog.Expressions/Expressions/Ast/IndexOfMatchExpression.cs
+++ b/src/Serilog.Expressions/Expressions/Ast/IndexOfMatchExpression.cs
@@ -13,5 +13,10 @@ namespace Serilog.Expressions.Ast
             Corpus = corpus ?? throw new ArgumentNullException(nameof(corpus));
             Regex = regex ?? throw new ArgumentNullException(nameof(regex));
         }
+
+        public override string ToString()
+        {
+            return $"_Internal_IndexOfMatch({Corpus}, '{Regex.ToString().Replace("'", "''")}')";
+        }
     }
 }

--- a/src/Serilog.Expressions/Expressions/Compilation/ExpressionCompiler.cs
+++ b/src/Serilog.Expressions/Expressions/Compilation/ExpressionCompiler.cs
@@ -10,7 +10,7 @@ namespace Serilog.Expressions.Compilation
 {
     static class ExpressionCompiler
     {
-        public static CompiledExpression Compile(Expression expression, NameResolver nameResolver)
+        public static Expression Translate(Expression expression)
         {
             var actual = expression;
             actual = VariadicCallRewriter.Rewrite(actual);
@@ -19,7 +19,12 @@ namespace Serilog.Expressions.Compilation
             actual = PropertiesObjectAccessorTransformer.Rewrite(actual);
             actual = ConstantArrayEvaluator.Evaluate(actual);
             actual = WildcardComprehensionTransformer.Expand(actual);
-
+            return actual;
+        }
+        
+        public static CompiledExpression Compile(Expression expression, NameResolver nameResolver)
+        {
+            var actual = Translate(expression);
             return LinqExpressionCompiler.Compile(actual, nameResolver);
         }
     }

--- a/src/Serilog.Expressions/Expressions/Compilation/Text/LikeSyntaxTransformer.cs
+++ b/src/Serilog.Expressions/Expressions/Compilation/Text/LikeSyntaxTransformer.cs
@@ -54,7 +54,10 @@ namespace Serilog.Expressions.Compilation.Text
         
         static string LikeToRegex(string like)
         {
+            var begin = "^";
             var regex = "";
+            var end = "$";
+            
             for (var i = 0; i < like.Length; ++i)
             {
                 var ch = like[i];
@@ -68,7 +71,17 @@ namespace Serilog.Expressions.Compilation.Text
                     }
                     else
                     {
-                        regex += "(?:.|\\r|\\n)*"; // ~= RegexOptions.Singleline
+                        if (i == 0)
+                            begin = "";
+                        
+                        if (i == like.Length - 1)
+                            end = "";
+                        
+                        if (i == 0 && i == like.Length - 1)
+                            regex += ".*";
+                        
+                        if (i != 0 && i != like.Length - 1)
+                            regex += "(?:.|\\r|\\n)*"; // ~= RegexOptions.Singleline
                     }
                 }
                 else if (ch == '_')
@@ -87,7 +100,7 @@ namespace Serilog.Expressions.Compilation.Text
                     regex += Regex.Escape(ch.ToString());
             }
 
-            return regex;
+            return begin + regex + end;
         }
     }
 }

--- a/src/Serilog.Expressions/Expressions/Compilation/Wildcards/WildcardSearch.cs
+++ b/src/Serilog.Expressions/Expressions/Compilation/Wildcards/WildcardSearch.cs
@@ -8,7 +8,7 @@ namespace Serilog.Expressions.Compilation.Wildcards
     {
         static readonly WildcardSearch Instance = new WildcardSearch();
         
-        public static IndexerExpression? FindElementAtWildcard(Expression fx)
+        public static IndexerExpression? FindWildcardIndexer(Expression fx)
         {
             return Instance.Transform(fx);
         }
@@ -59,6 +59,11 @@ namespace Serilog.Expressions.Compilation.Wildcards
 
         protected override IndexerExpression? Transform(CallExpression lx)
         {
+            // If we hit a wildcard-compatible operation, then any wildcards within its operands "belong" to
+            // it and can't be the result of this search.
+            if (Operators.WildcardComparators.Contains(lx.OperatorName))
+                return null;
+    
             return lx.Operands.Select(Transform).FirstOrDefault(e => e != null);
         }
 

--- a/src/Serilog.Expressions/Expressions/Parsing/ExpressionParser.cs
+++ b/src/Serilog.Expressions/Expressions/Parsing/ExpressionParser.cs
@@ -8,9 +8,9 @@ namespace Serilog.Expressions.Parsing
     {
         static ExpressionTokenizer Tokenizer { get; } = new ExpressionTokenizer();
         
-        public static Expression Parse(string filterExpression)
+        public static Expression Parse(string expression)
         {
-            if (!TryParse(filterExpression, out var root, out var error))
+            if (!TryParse(expression, out var root, out var error))
                 throw new ArgumentException(error);
 
             return root;

--- a/src/Serilog.Expressions/Expressions/SerilogExpression.cs
+++ b/src/Serilog.Expressions/Expressions/SerilogExpression.cs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Serilog.Expressions.Compilation;

--- a/test/Serilog.Expressions.Tests/Cases/expression-evaluation-cases.asv
+++ b/test/Serilog.Expressions.Tests/Cases/expression-evaluation-cases.asv
@@ -267,3 +267,7 @@ undefined() = undefined() ci         ⇶ undefined()
 'test' like '%s_'                    ⇶ true
 'test' like '%'                      ⇶ true
 'test' like 't%s%'                   ⇶ true
+'test' like 'es'                     ⇶ false
+'test' like '%'                      ⇶ true
+'test' like ''                       ⇶ false
+'' like ''                           ⇶ true

--- a/test/Serilog.Expressions.Tests/Cases/translation-cases.asv
+++ b/test/Serilog.Expressions.Tests/Cases/translation-cases.asv
@@ -1,0 +1,16 @@
+﻿// Like
+A like 'a'                                    ⇶ _Internal_NotEqual(_Internal_IndexOfMatch(A, '^a$'), -1)
+A like 'a%'                                   ⇶ _Internal_NotEqual(_Internal_IndexOfMatch(A, '^a'), -1)
+A like '%a%'                                  ⇶ _Internal_NotEqual(_Internal_IndexOfMatch(A, 'a'), -1)
+A like '%a'                                   ⇶ _Internal_NotEqual(_Internal_IndexOfMatch(A, 'a$'), -1)
+A like '%a_b%'                                ⇶ _Internal_NotEqual(_Internal_IndexOfMatch(A, 'a.b'), -1)
+A like 'a%b%'                                 ⇶ _Internal_NotEqual(_Internal_IndexOfMatch(A, '^a(?:.|\r|\n)*b'), -1)
+A like '%'                                    ⇶ _Internal_NotEqual(_Internal_IndexOfMatch(A, '.*'), -1)
+
+// Variadics
+coalesce(A, B, C, D)                          ⇶ coalesce(A, coalesce(B, coalesce(C, D)))
+
+// Wildcards!
+A[?]                                          ⇶ _Internal_Any(A, |$$p0| {$$p0})
+A or B[*]                                     ⇶ _Internal_Or(A, _Internal_All(B, |$$p0| {$$p0}))
+not (A is not null) or not (A[?] = 'a')       ⇶ _Internal_Or(_Internal_Not(_Internal_IsNotNull(A)), _Internal_Not(_Internal_Any(A, |$$p0| {_Internal_Equal($$p0, 'a')})))

--- a/test/Serilog.Expressions.Tests/Cases/translation-cases.asv
+++ b/test/Serilog.Expressions.Tests/Cases/translation-cases.asv
@@ -7,6 +7,10 @@ A like '%a_b%'                                ⇶ _Internal_NotEqual(_Internal_I
 A like 'a%b%'                                 ⇶ _Internal_NotEqual(_Internal_IndexOfMatch(A, '^a(?:.|\r|\n)*b'), -1)
 A like '%'                                    ⇶ _Internal_NotEqual(_Internal_IndexOfMatch(A, '.*'), -1)
 
+// Root properties
+@p['Test']                                    ⇶ Test
+@p[Test]                                      ⇶ @p[Test]
+
 // Variadics
 coalesce(A, B, C, D)                          ⇶ coalesce(A, coalesce(B, coalesce(C, D)))
 

--- a/test/Serilog.Expressions.Tests/ExpressionEvaluationTests.cs
+++ b/test/Serilog.Expressions.Tests/ExpressionEvaluationTests.cs
@@ -11,20 +11,8 @@ namespace Serilog.Expressions.Tests
 {
     public class ExpressionEvaluationTests
     {
-        static readonly string CasesPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory!, "Cases");
-
-        static IEnumerable<object[]> ReadCases(string filename)
-        {
-            foreach (var line in File.ReadLines(Path.Combine(CasesPath, filename)))
-            {
-                var cols = line.Split("⇶", StringSplitOptions.RemoveEmptyEntries);
-                if (cols.Length == 2)
-                    yield return cols.Select(c => c.Trim()).ToArray<object>();
-            }
-        }
-
         public static IEnumerable<object[]> ExpressionEvaluationCases =>
-            ReadCases("expression-evaluation-cases.asv");
+            AsvCases.ReadCases("expression-evaluation-cases.asv");
 
         [Theory]
         [MemberData(nameof(ExpressionEvaluationCases))]

--- a/test/Serilog.Expressions.Tests/ExpressionTranslationTests.cs
+++ b/test/Serilog.Expressions.Tests/ExpressionTranslationTests.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Serilog.Events;
+using Serilog.Expressions.Compilation;
+using Serilog.Expressions.Parsing;
+using Serilog.Expressions.Runtime;
+using Serilog.Expressions.Tests.Support;
+using Xunit;
+
+namespace Serilog.Expressions.Tests
+{
+    public class ExpressionTranslationTests
+    {
+        public static IEnumerable<object[]> ExpressionEvaluationCases =>
+            AsvCases.ReadCases("translation-cases.asv");
+
+        [Theory]
+        [MemberData(nameof(ExpressionEvaluationCases))]
+        public void ExpressionsAreCorrectlyTranslated(string expr, string expected)
+        {
+            var parsed = ExpressionParser.Parse(expr);
+            var translated = ExpressionCompiler.Translate(parsed);
+            var actual = translated.ToString();
+            Assert.Equal(expected, actual);
+        }
+    }
+}

--- a/test/Serilog.Expressions.Tests/Support/AsvCases.cs
+++ b/test/Serilog.Expressions.Tests/Support/AsvCases.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Serilog.Expressions.Tests.Support
+{
+    // "Arrow-separated values ;-) ... convenient because the Unicode `⇶` character doesn't appear in
+    // any of the cases themselves, and so we ignore any need for special character escaping (which is
+    // troublesome when the language the cases are written in uses just about all special characters somehow
+    // or other!).
+    //
+    // The ASV format informally supports `//` comment lines, as long as they don't contain the arrow character.
+    static class AsvCases
+    {
+        static readonly string CasesPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory!, "Cases");
+
+        public static IEnumerable<object[]> ReadCases(string filename)
+        {
+            return from line in File.ReadLines(Path.Combine(CasesPath, filename))
+                select line.Split("⇶", StringSplitOptions.RemoveEmptyEntries) into cols
+                where cols.Length == 2
+                select cols.Select(c => c.Trim()).ToArray<object>();
+        }
+    }
+}

--- a/test/Serilog.Expressions.Tests/TemplateEvaluationTests.cs
+++ b/test/Serilog.Expressions.Tests/TemplateEvaluationTests.cs
@@ -10,20 +10,8 @@ namespace Serilog.Expressions.Tests
 {
     public class TemplateEvaluationTests
     {
-        static readonly string CasesPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory!, "Cases");
-
-        static IEnumerable<object[]> ReadCases(string filename)
-        {
-            foreach (var line in File.ReadLines(Path.Combine(CasesPath, filename)))
-            {
-                var cols = line.Split("⇶", StringSplitOptions.RemoveEmptyEntries);
-                if (cols.Length == 2)
-                    yield return cols.Select(c => c.Trim()).ToArray<object>();
-            }
-        }
-
         public static IEnumerable<object[]> TemplateEvaluationCases =>
-            ReadCases("template-evaluation-cases.asv");
+            AsvCases.ReadCases("template-evaluation-cases.asv");
 
         [Theory]
         [MemberData(nameof(TemplateEvaluationCases))]


### PR DESCRIPTION
_Serilog.Expressions_ has a number of language features in common with Seq (though the implementations are generally very different). I checked over how wildcards are evaluated after having a [bug reported in Seq's implementation](https://github.com/datalust/seq-tickets/issues/1150), to see whether similar issues existed over here.

And, yes! - Found some problems in how wildcards work, leading to potentially incorrect results in the presence of indexing into potentially-undefined values.

After adding some new test cases for that issue, I fleshed out testing of `like` and found that expressions aren't being correctly anchored, here - `A like 'a%'` should anchor `a` at the beginning of the target string, but doesn't, and end anchoring was similarly broken.

This PR fixes both sets of issues.