### PR TITLE
Additional wildcard comprehension test case and fix

### DIFF
--- a/src/Serilog.Expressions/Expressions/Operators.cs
+++ b/src/Serilog.Expressions/Expressions/Operators.cs
@@ -80,7 +80,9 @@ namespace Serilog.Expressions
             OpIsMatch,
             OpIsDefined,
             RuntimeOpIsNull,
-            RuntimeOpIsNotNull
+            RuntimeOpIsNotNull,
+            RuntimeOpAny,
+            RuntimeOpAll
         };
 
         public static bool SameOperator(string op1, string op2)

--- a/test/Serilog.Expressions.Tests/Cases/translation-cases.asv
+++ b/test/Serilog.Expressions.Tests/Cases/translation-cases.asv
@@ -18,3 +18,4 @@ coalesce(A, B, C, D)                          ⇶ coalesce(A, coalesce(B, coales
 A[?]                                          ⇶ _Internal_Any(A, |$$p0| {$$p0})
 A or B[*]                                     ⇶ _Internal_Or(A, _Internal_All(B, |$$p0| {$$p0}))
 not (A is not null) or not (A[?] = 'a')       ⇶ _Internal_Or(_Internal_Not(_Internal_IsNotNull(A)), _Internal_Not(_Internal_Any(A, |$$p0| {_Internal_Equal($$p0, 'a')})))
+A[?].B[*].C = D                               ⇶ _Internal_Any(A, |$$p1| {_Internal_All($$p1.B, |$$p0| {_Internal_Equal($$p0.C, D)})})


### PR DESCRIPTION
Missed one vital detail, leading to multi-wildcard paths not being transformed correctly.