### PR TITLE
ANSI terminal themes; culture-specific formatting

### DIFF
--- a/example/Sample/Program.cs
+++ b/example/Sample/Program.cs
@@ -2,6 +2,7 @@
 using Serilog;
 using Serilog.Debugging;
 using Serilog.Templates;
+using Serilog.Templates.Themes;
 
 namespace Sample
 {
@@ -82,7 +83,8 @@ namespace Sample
                     "      {#each s in Scope}=> {s}{#delimit} {#end}\n" +
                     "{#end}" +
                     "      {@m}\n" +
-                    "{@x}"))
+                    "{@x}",
+                    theme: TemplateTheme.Code))
                 .CreateLogger();
 
             var program = log.ForContext<Program>();

--- a/example/Sample/Program.cs
+++ b/example/Sample/Program.cs
@@ -26,7 +26,8 @@ namespace Sample
                 .WriteTo.Console(new ExpressionTemplate(
                     "[{@t:HH:mm:ss} {@l:u3}" +
                     "{#if SourceContext is not null} ({Substring(SourceContext, LastIndexOf(SourceContext, '.') + 1)}){#end}] " +
-                    "{@m} (first item is {coalesce(Items[0], '<empty>')})\n{@x}"))
+                    "{@m} (first item is {coalesce(Items[0], '<empty>')})\n{@x}",
+                    theme: TemplateTheme.Code))
                 .CreateLogger();
 
             log.Information("Running {Example}", nameof(TextFormattingExample1));
@@ -43,8 +44,7 @@ namespace Sample
             using var log = new LoggerConfiguration()
                 .Enrich.WithProperty("Application", "Example")
                 .WriteTo.Console(new ExpressionTemplate(
-                    "{ {@t: UtcDateTime(@t), @mt, @l: if @l = 'Information' then undefined() else @l, @x, ..@p} }\n",
-                    theme: TemplateTheme.Code))
+                    "{ {@t: UtcDateTime(@t), @mt, @l: if @l = 'Information' then undefined() else @l, @x, ..@p} }\n"))
                 .CreateLogger();
 
             log.Information("Running {Example}", nameof(JsonFormattingExample));
@@ -84,8 +84,8 @@ namespace Sample
             {
                 // `Information` is dark green in MEL.
                 [TemplateThemeStyle.LevelInformation] = "\x1b[38;5;34m",
-                [TemplateThemeStyle.String] = "\x1b[38;5;33m",
-                [TemplateThemeStyle.Number] = "\x1b[38;5;93m"
+                [TemplateThemeStyle.String] = "\x1b[38;5;138m",
+                [TemplateThemeStyle.Number] = "\x1b[38;5;140m"
             });
 
             using var log = new LoggerConfiguration()
@@ -100,11 +100,13 @@ namespace Sample
                 .CreateLogger();
 
             var program = log.ForContext<Program>();
-            program.Information("Starting up");
+            program.Information("Host listening at {ListenUri}", "https://hello-world.local");
             
             program
                 .ForContext("Scope", new[] {"Main", "TextFormattingExample2()"})
-                .Information("Hello, {Name} x {Number}!", "world", 42);
+                .Information("HTTP {Method} {Path} responded {StatusCode} in {Elapsed:0.000} ms", "GET", "/api/hello", 200, 1.23);
+            
+            program.Warning("We've reached the end of the line");
         }
     }
 }

--- a/example/Sample/Program.cs
+++ b/example/Sample/Program.cs
@@ -84,8 +84,8 @@ namespace Sample
             {
                 // `Information` is dark green in MEL.
                 [TemplateThemeStyle.LevelInformation] = "\x1b[38;5;34m",
-                [TemplateThemeStyle.String] = "\x1b[38;5;138m",
-                [TemplateThemeStyle.Number] = "\x1b[38;5;140m"
+                [TemplateThemeStyle.String] = "\x1b[38;5;159m",
+                [TemplateThemeStyle.Number] = "\x1b[38;5;159m"
             });
 
             using var log = new LoggerConfiguration()

--- a/example/Sample/Program.cs
+++ b/example/Sample/Program.cs
@@ -95,7 +95,7 @@ namespace Sample
             // Emulate data produced by the Serilog.AspNetCore integration
             var scoped = program.ForContext("Scope", new[] {"Main", "TextFormattingExample2()"});
 
-            scoped.Information("Hello, world!");
+            scoped.Information("Hello, {Name} x {Number}!", "world", 42);
         }
     }
 }

--- a/example/Sample/Program.cs
+++ b/example/Sample/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using Serilog;
 using Serilog.Debugging;
 using Serilog.Templates;
@@ -42,7 +43,8 @@ namespace Sample
             using var log = new LoggerConfiguration()
                 .Enrich.WithProperty("Application", "Example")
                 .WriteTo.Console(new ExpressionTemplate(
-                    "{ {@t, @mt, @l: if @l = 'Information' then undefined() else @l, @x, ..@p} }\n"))
+                    "{ {@t, @mt, @l: if @l = 'Information' then undefined() else @l, @x, ..@p} }\n",
+                    theme: TemplateTheme.Code))
                 .CreateLogger();
 
             log.Information("Running {Example}", nameof(JsonFormattingExample));
@@ -84,7 +86,7 @@ namespace Sample
                     "{#end}" +
                     "      {@m}\n" +
                     "{@x}",
-                    theme: TemplateTheme.Code))
+                    theme: TemplateTheme.Literate))
                 .CreateLogger();
 
             var program = log.ForContext<Program>();
@@ -92,8 +94,10 @@ namespace Sample
             
             // Emulate data produced by the Serilog.AspNetCore integration
             var scoped = program.ForContext("Scope", new[] {"Main", "TextFormattingExample2()"});
-            
-            scoped.Information("Hello, world!");
+
+            var ex = new DivideByZeroException();
+            try { throw ex; } catch {}
+            scoped.Information(ex, "Hello, world!");
         }
     }
 }

--- a/example/Sample/Program.cs
+++ b/example/Sample/Program.cs
@@ -43,7 +43,7 @@ namespace Sample
             using var log = new LoggerConfiguration()
                 .Enrich.WithProperty("Application", "Example")
                 .WriteTo.Console(new ExpressionTemplate(
-                    "{ {@t, @mt, @l: if @l = 'Information' then undefined() else @l, @x, ..@p} }\n",
+                    "{ {@t: UtcDateTime(@t), @mt, @l: if @l = 'Information' then undefined() else @l, @x, ..@p} }\n",
                     theme: TemplateTheme.Code))
                 .CreateLogger();
 
@@ -95,9 +95,7 @@ namespace Sample
             // Emulate data produced by the Serilog.AspNetCore integration
             var scoped = program.ForContext("Scope", new[] {"Main", "TextFormattingExample2()"});
 
-            var ex = new DivideByZeroException();
-            try { throw ex; } catch {}
-            scoped.Information(ex, "Hello, world!");
+            scoped.Information("Hello, world!");
         }
     }
 }

--- a/example/Sample/Program.cs
+++ b/example/Sample/Program.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using System.Diagnostics;
+using System.Collections.Generic;
 using Serilog;
 using Serilog.Debugging;
 using Serilog.Templates;
@@ -78,6 +78,16 @@ namespace Sample
         
         static void TextFormattingExample2()
         {
+            // Emulates `Microsoft.Extensions.Logging`'s `ConsoleLogger`.
+            
+            var melon = new TemplateTheme(TemplateTheme.Literate, new Dictionary<TemplateThemeStyle, string>
+            {
+                // `Information` is dark green in MEL.
+                [TemplateThemeStyle.LevelInformation] = "\x1b[38;5;34m",
+                [TemplateThemeStyle.String] = "\x1b[38;5;33m",
+                [TemplateThemeStyle.Number] = "\x1b[38;5;93m"
+            });
+
             using var log = new LoggerConfiguration()
                 .WriteTo.Console(new ExpressionTemplate(
                     "{@l:w4}: {SourceContext}\n" +
@@ -86,16 +96,15 @@ namespace Sample
                     "{#end}" +
                     "      {@m}\n" +
                     "{@x}",
-                    theme: TemplateTheme.Literate))
+                    theme: melon))
                 .CreateLogger();
 
             var program = log.ForContext<Program>();
             program.Information("Starting up");
             
-            // Emulate data produced by the Serilog.AspNetCore integration
-            var scoped = program.ForContext("Scope", new[] {"Main", "TextFormattingExample2()"});
-
-            scoped.Information("Hello, {Name} x {Number}!", "world", 42);
+            program
+                .ForContext("Scope", new[] {"Main", "TextFormattingExample2()"})
+                .Information("Hello, {Name} x {Number}!", "world", 42);
         }
     }
 }

--- a/example/Sample/Sample.csproj
+++ b/example/Sample/Sample.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 

--- a/serilog-expressions.sln.DotSettings
+++ b/serilog-expressions.sln.DotSettings
@@ -1,6 +1,7 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Acerola/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Comparand/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=delim/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Enricher/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Evaluatable/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Existentials/@EntryIndexedValue">True</s:Boolean>

--- a/src/Serilog.Expressions/Expressions/Ast/AccessorExpression.cs
+++ b/src/Serilog.Expressions/Expressions/Ast/AccessorExpression.cs
@@ -1,4 +1,18 @@
-﻿using System;
+﻿// Copyright © Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 
 namespace Serilog.Expressions.Ast
 {

--- a/src/Serilog.Expressions/Expressions/Ast/AmbientNameExpression.cs
+++ b/src/Serilog.Expressions/Expressions/Ast/AmbientNameExpression.cs
@@ -1,4 +1,18 @@
-﻿using System;
+﻿// Copyright © Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 
 namespace Serilog.Expressions.Ast
 {
@@ -6,11 +20,11 @@ namespace Serilog.Expressions.Ast
     {
         readonly bool _requiresEscape;
 
-        public AmbientNameExpression(string Name, bool isBuiltIn)
+        public AmbientNameExpression(string name, bool isBuiltIn)
         {
-            PropertyName = Name ?? throw new ArgumentNullException(nameof(Name));
+            PropertyName = name ?? throw new ArgumentNullException(nameof(name));
             IsBuiltIn = isBuiltIn;
-            _requiresEscape = !SerilogExpression.IsValidIdentifier(Name);
+            _requiresEscape = !SerilogExpression.IsValidIdentifier(name);
         }
 
         public string PropertyName { get; }

--- a/src/Serilog.Expressions/Expressions/Ast/ArrayExpression.cs
+++ b/src/Serilog.Expressions/Expressions/Ast/ArrayExpression.cs
@@ -1,4 +1,18 @@
-﻿using System;
+﻿// Copyright © Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 using System.Linq;
 
 namespace Serilog.Expressions.Ast

--- a/src/Serilog.Expressions/Expressions/Ast/CallExpression.cs
+++ b/src/Serilog.Expressions/Expressions/Ast/CallExpression.cs
@@ -1,4 +1,18 @@
-﻿using System;
+﻿// Copyright © Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 using System.Linq;
 
 namespace Serilog.Expressions.Ast

--- a/src/Serilog.Expressions/Expressions/Ast/ConstantExpression.cs
+++ b/src/Serilog.Expressions/Expressions/Ast/ConstantExpression.cs
@@ -1,4 +1,18 @@
-﻿using System;
+﻿// Copyright © Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 using System.Globalization;
 using Serilog.Events;
 

--- a/src/Serilog.Expressions/Expressions/Ast/Element.cs
+++ b/src/Serilog.Expressions/Expressions/Ast/Element.cs
@@ -1,4 +1,18 @@
-﻿namespace Serilog.Expressions.Ast
+﻿// Copyright © Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Serilog.Expressions.Ast
 {
     abstract class Element
     {

--- a/src/Serilog.Expressions/Expressions/Ast/Expression.cs
+++ b/src/Serilog.Expressions/Expressions/Ast/Expression.cs
@@ -1,4 +1,18 @@
-﻿namespace Serilog.Expressions.Ast
+﻿// Copyright © Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Serilog.Expressions.Ast
 {
     abstract class Expression
     {

--- a/src/Serilog.Expressions/Expressions/Ast/IndexOfMatchExpression.cs
+++ b/src/Serilog.Expressions/Expressions/Ast/IndexOfMatchExpression.cs
@@ -1,3 +1,17 @@
+// Copyright © Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 using System;
 using System.Text.RegularExpressions;
 

--- a/src/Serilog.Expressions/Expressions/Ast/IndexerExpression.cs
+++ b/src/Serilog.Expressions/Expressions/Ast/IndexerExpression.cs
@@ -1,3 +1,17 @@
+// Copyright © Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 namespace Serilog.Expressions.Ast
 {
     class IndexerExpression : Expression

--- a/src/Serilog.Expressions/Expressions/Ast/IndexerWildcard.cs
+++ b/src/Serilog.Expressions/Expressions/Ast/IndexerWildcard.cs
@@ -1,4 +1,18 @@
-﻿namespace Serilog.Expressions.Ast
+﻿// Copyright © Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Serilog.Expressions.Ast
 {
     enum IndexerWildcard { Undefined, Any, All }
 }

--- a/src/Serilog.Expressions/Expressions/Ast/IndexerWildcardExpression.cs
+++ b/src/Serilog.Expressions/Expressions/Ast/IndexerWildcardExpression.cs
@@ -1,4 +1,18 @@
-﻿using System;
+﻿// Copyright © Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 
 namespace Serilog.Expressions.Ast
 {

--- a/src/Serilog.Expressions/Expressions/Ast/ItemElement.cs
+++ b/src/Serilog.Expressions/Expressions/Ast/ItemElement.cs
@@ -1,4 +1,18 @@
-﻿namespace Serilog.Expressions.Ast
+﻿// Copyright © Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Serilog.Expressions.Ast
 {
     class ItemElement : Element
     {

--- a/src/Serilog.Expressions/Expressions/Ast/LambdaExpression.cs
+++ b/src/Serilog.Expressions/Expressions/Ast/LambdaExpression.cs
@@ -1,3 +1,17 @@
+// Copyright © Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 using System.Linq;
 
 namespace Serilog.Expressions.Ast

--- a/src/Serilog.Expressions/Expressions/Ast/LocalNameExpression.cs
+++ b/src/Serilog.Expressions/Expressions/Ast/LocalNameExpression.cs
@@ -1,4 +1,18 @@
-﻿using System;
+﻿// Copyright © Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 
 namespace Serilog.Expressions.Ast
 {

--- a/src/Serilog.Expressions/Expressions/Ast/Member.cs
+++ b/src/Serilog.Expressions/Expressions/Ast/Member.cs
@@ -1,4 +1,18 @@
-﻿namespace Serilog.Expressions.Ast
+﻿// Copyright © Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Serilog.Expressions.Ast
 {
     abstract class Member
     {

--- a/src/Serilog.Expressions/Expressions/Ast/ObjectExpression.cs
+++ b/src/Serilog.Expressions/Expressions/Ast/ObjectExpression.cs
@@ -1,3 +1,17 @@
+// Copyright © Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 using System.Linq;
 
 namespace Serilog.Expressions.Ast

--- a/src/Serilog.Expressions/Expressions/Ast/ParameterExpression.cs
+++ b/src/Serilog.Expressions/Expressions/Ast/ParameterExpression.cs
@@ -1,3 +1,17 @@
+// Copyright © Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 namespace Serilog.Expressions.Ast
 {
     class ParameterExpression : Expression

--- a/src/Serilog.Expressions/Expressions/Ast/PropertyMember.cs
+++ b/src/Serilog.Expressions/Expressions/Ast/PropertyMember.cs
@@ -1,4 +1,18 @@
-﻿using Serilog.Events;
+﻿// Copyright © Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Serilog.Events;
 
 namespace Serilog.Expressions.Ast
 {

--- a/src/Serilog.Expressions/Expressions/Ast/SpreadElement.cs
+++ b/src/Serilog.Expressions/Expressions/Ast/SpreadElement.cs
@@ -1,4 +1,18 @@
-﻿namespace Serilog.Expressions.Ast
+﻿// Copyright © Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Serilog.Expressions.Ast
 {
     class SpreadElement : Element
     {

--- a/src/Serilog.Expressions/Expressions/Ast/SpreadMember.cs
+++ b/src/Serilog.Expressions/Expressions/Ast/SpreadMember.cs
@@ -1,4 +1,18 @@
-﻿namespace Serilog.Expressions.Ast
+﻿// Copyright © Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Serilog.Expressions.Ast
 {
     class SpreadMember : Member
     {

--- a/src/Serilog.Expressions/Expressions/Compilation/Arrays/ConstantArrayEvaluator.cs
+++ b/src/Serilog.Expressions/Expressions/Compilation/Arrays/ConstantArrayEvaluator.cs
@@ -1,4 +1,18 @@
-﻿using System.Linq;
+﻿// Copyright © Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Linq;
 using Serilog.Events;
 using Serilog.Expressions.Ast;
 using Serilog.Expressions.Compilation.Transformations;

--- a/src/Serilog.Expressions/Expressions/Compilation/DefaultFunctionNameResolver.cs
+++ b/src/Serilog.Expressions/Expressions/Compilation/DefaultFunctionNameResolver.cs
@@ -1,4 +1,18 @@
-﻿using Serilog.Expressions.Runtime;
+﻿// Copyright © Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Serilog.Expressions.Runtime;
 
 namespace Serilog.Expressions.Compilation
 {

--- a/src/Serilog.Expressions/Expressions/Compilation/ExpressionCompiler.cs
+++ b/src/Serilog.Expressions/Expressions/Compilation/ExpressionCompiler.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System;
 using Serilog.Expressions.Ast;
 using Serilog.Expressions.Compilation.Arrays;
 using Serilog.Expressions.Compilation.Linq;
@@ -36,10 +37,11 @@ namespace Serilog.Expressions.Compilation
             return actual;
         }
         
-        public static Evaluatable Compile(Expression expression, NameResolver nameResolver)
+        public static Evaluatable Compile(Expression expression, IFormatProvider? formatProvider,
+            NameResolver nameResolver)
         {
             var actual = Translate(expression);
-            return LinqExpressionCompiler.Compile(actual, nameResolver);
+            return LinqExpressionCompiler.Compile(actual, formatProvider, nameResolver);
         }
     }
 }

--- a/src/Serilog.Expressions/Expressions/Compilation/ExpressionCompiler.cs
+++ b/src/Serilog.Expressions/Expressions/Compilation/ExpressionCompiler.cs
@@ -1,4 +1,18 @@
-﻿using Serilog.Expressions.Ast;
+﻿// Copyright © Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Serilog.Expressions.Ast;
 using Serilog.Expressions.Compilation.Arrays;
 using Serilog.Expressions.Compilation.Linq;
 using Serilog.Expressions.Compilation.Properties;

--- a/src/Serilog.Expressions/Expressions/Compilation/Linq/ExpressionConstantMapper.cs
+++ b/src/Serilog.Expressions/Expressions/Compilation/Linq/ExpressionConstantMapper.cs
@@ -1,4 +1,18 @@
-﻿using System.Collections.Generic;
+﻿// Copyright © Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.Generic;
 using System.Linq.Expressions;
 using Serilog.Events;
 

--- a/src/Serilog.Expressions/Expressions/Compilation/Linq/Intrinsics.cs
+++ b/src/Serilog.Expressions/Expressions/Compilation/Linq/Intrinsics.cs
@@ -27,13 +27,13 @@ using Serilog.Parsing;
 
 namespace Serilog.Expressions.Compilation.Linq
 {
-    static class Intrinsics
+    class Intrinsics
     {
         static readonly LogEventPropertyValue NegativeOne = new ScalarValue(-1);
         static readonly LogEventPropertyValue Tombstone = new ScalarValue("😬 (if you see this you have found a bug.)");
         
         // TODO #19: formatting is culture-specific.
-        static readonly MessageTemplateTextFormatter MessageFormatter = new MessageTemplateTextFormatter("{Message:lj}");
+        static readonly MessageTemplateTextFormatter MessageFormatter = new("{Message:lj}");
 
         public static List<LogEventPropertyValue?> CollectSequenceElements(LogEventPropertyValue?[] elements)
         {
@@ -191,7 +191,7 @@ namespace Serilog.Expressions.Compilation.Linq
             List<LogEventPropertyValue>? elements = null;
             foreach (var token in logEvent.MessageTemplate.Tokens)
             {
-                if (token is PropertyToken pt && pt.Format != null)
+                if (token is PropertyToken {Format: { }} pt)
                 {
                     elements ??= new List<LogEventPropertyValue>();
                     

--- a/src/Serilog.Expressions/Expressions/Compilation/Linq/Intrinsics.cs
+++ b/src/Serilog.Expressions/Expressions/Compilation/Linq/Intrinsics.cs
@@ -1,4 +1,18 @@
-﻿using System;
+﻿// Copyright © Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.IO;

--- a/src/Serilog.Expressions/Expressions/Compilation/Linq/LinqExpressionCompiler.cs
+++ b/src/Serilog.Expressions/Expressions/Compilation/Linq/LinqExpressionCompiler.cs
@@ -141,6 +141,7 @@ namespace Serilog.Expressions.Compilation.Linq
                 return px.PropertyName switch
                 {
                     BuiltInProperty.Level => Splice(context => new ScalarValue(context.LogEvent.Level)),
+                    // TODO: for consistency, this should call (an extract of) `CompiledMessageToken.Evaluate(ctx, output)`.
                     BuiltInProperty.Message => Splice(context => new ScalarValue(Intrinsics.RenderMessage(context.LogEvent))),
                     BuiltInProperty.Exception => Splice(context =>
                         context.LogEvent.Exception == null ? null : new ScalarValue(context.LogEvent.Exception)),

--- a/src/Serilog.Expressions/Expressions/Compilation/Linq/LinqExpressionCompiler.cs
+++ b/src/Serilog.Expressions/Expressions/Compilation/Linq/LinqExpressionCompiler.cs
@@ -20,6 +20,8 @@ using System.Reflection;
 using Serilog.Events;
 using Serilog.Expressions.Ast;
 using Serilog.Expressions.Compilation.Transformations;
+using Serilog.Templates.Compilation;
+using Serilog.Templates.Themes;
 using ConstantExpression = Serilog.Expressions.Ast.ConstantExpression;
 using Expression = Serilog.Expressions.Ast.Expression;
 using ParameterExpression = System.Linq.Expressions.ParameterExpression;
@@ -31,6 +33,7 @@ namespace Serilog.Expressions.Compilation.Linq
     class LinqExpressionCompiler : SerilogExpressionTransformer<ExpressionBody>
     {
         readonly NameResolver _nameResolver;
+        readonly IFormatProvider? _formatProvider;
 
         static readonly MethodInfo CollectSequenceElementsMethod = typeof(Intrinsics)
             .GetMethod(nameof(Intrinsics.CollectSequenceElements), BindingFlags.Static | BindingFlags.Public)!;
@@ -70,15 +73,17 @@ namespace Serilog.Expressions.Compilation.Linq
 
         ParameterExpression Context { get; } = LX.Variable(typeof(EvaluationContext), "ctx");
 
-        LinqExpressionCompiler(NameResolver nameResolver)
+        LinqExpressionCompiler(IFormatProvider? formatProvider, NameResolver nameResolver)
         {
             _nameResolver = nameResolver;
+            _formatProvider = formatProvider;
         }
         
-        public static Evaluatable Compile(Expression expression, NameResolver nameResolver)
+        public static Evaluatable Compile(Expression expression, IFormatProvider? formatProvider,
+            NameResolver nameResolver)
         {
             if (expression == null) throw new ArgumentNullException(nameof(expression));
-            var compiler = new LinqExpressionCompiler(nameResolver);
+            var compiler = new LinqExpressionCompiler(formatProvider, nameResolver);
             var body = compiler.Transform(expression); 
             return LX.Lambda<Evaluatable>(body, compiler.Context).Compile();
         }
@@ -93,7 +98,9 @@ namespace Serilog.Expressions.Compilation.Linq
             if (!_nameResolver.TryResolveFunctionName(lx.OperatorName, out var m))
                 throw new ArgumentException($"The function name `{lx.OperatorName}` was not recognized.");
 
-            var parameterCount = m.GetParameters().Count(pi => pi.ParameterType == typeof(LogEventPropertyValue));
+            var methodParameters = m.GetParameters();
+            
+            var parameterCount = methodParameters.Count(pi => pi.ParameterType == typeof(LogEventPropertyValue));
             if (parameterCount != lx.Operands.Length)
                 throw new ArgumentException($"The function `{lx.OperatorName}` requires {parameterCount} arguments.");
 
@@ -106,9 +113,15 @@ namespace Serilog.Expressions.Compilation.Linq
             if (Operators.SameOperator(lx.OperatorName, Operators.RuntimeOpOr))
                 return CompileLogical(LX.OrElse, operands[0], operands[1]);
 
-            if (m.GetParameters().Any(pi => pi.ParameterType == typeof(StringComparison)))
-                operands.Insert(0, LX.Constant(lx.IgnoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal));
-
+            for (var i = 0; i < methodParameters.Length; ++i)
+            {
+                var pi = methodParameters[i];
+                if (pi.ParameterType == typeof(StringComparison))
+                    operands.Insert(i, LX.Constant(lx.IgnoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal));
+                else if (pi.ParameterType == typeof(IFormatProvider))
+                    operands.Insert(i, LX.Constant(_formatProvider, typeof(IFormatProvider)));
+            }
+            
             return LX.Call(m, operands);
         }
 
@@ -138,11 +151,13 @@ namespace Serilog.Expressions.Compilation.Linq
         {
             if (px.IsBuiltIn)
             {
+                var formatter = new CompiledMessageToken(_formatProvider, null, TemplateTheme.None);
+                var formatProvider = _formatProvider;
+                
                 return px.PropertyName switch
                 {
                     BuiltInProperty.Level => Splice(context => new ScalarValue(context.LogEvent.Level)),
-                    // TODO: for consistency, this should call (an extract of) `CompiledMessageToken.Evaluate(ctx, output)`.
-                    BuiltInProperty.Message => Splice(context => new ScalarValue(Intrinsics.RenderMessage(context.LogEvent))),
+                    BuiltInProperty.Message => Splice(context => new ScalarValue(Intrinsics.RenderMessage(formatter, context))),
                     BuiltInProperty.Exception => Splice(context =>
                         context.LogEvent.Exception == null ? null : new ScalarValue(context.LogEvent.Exception)),
                     BuiltInProperty.Timestamp => Splice(context => new ScalarValue(context.LogEvent.Timestamp)),
@@ -150,7 +165,7 @@ namespace Serilog.Expressions.Compilation.Linq
                     BuiltInProperty.Properties => Splice(context =>
                         new StructureValue(context.LogEvent.Properties.Select(kvp => new LogEventProperty(kvp.Key, kvp.Value)),
                             null)),
-                    BuiltInProperty.Renderings => Splice(context => Intrinsics.GetRenderings(context.LogEvent)),
+                    BuiltInProperty.Renderings => Splice(context => Intrinsics.GetRenderings(context.LogEvent, formatProvider)),
                     BuiltInProperty.EventId => Splice(context =>
                         new ScalarValue(EventIdHash.Compute(context.LogEvent.MessageTemplate.Text))),
                     _ => LX.Constant(null, typeof(LogEventPropertyValue))

--- a/src/Serilog.Expressions/Expressions/Compilation/Linq/ParameterReplacementVisitor.cs
+++ b/src/Serilog.Expressions/Expressions/Compilation/Linq/ParameterReplacementVisitor.cs
@@ -1,4 +1,18 @@
-﻿using System;
+﻿// Copyright © Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 using System.Linq;
 using System.Linq.Expressions;
 

--- a/src/Serilog.Expressions/Expressions/Compilation/OrderedNameResolver.cs
+++ b/src/Serilog.Expressions/Expressions/Compilation/OrderedNameResolver.cs
@@ -1,4 +1,18 @@
-﻿using System.Collections.Generic;
+﻿// Copyright © Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;

--- a/src/Serilog.Expressions/Expressions/Compilation/Pattern.cs
+++ b/src/Serilog.Expressions/Expressions/Compilation/Pattern.cs
@@ -1,3 +1,17 @@
+// Copyright © Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 using System.Diagnostics.CodeAnalysis;
 using Serilog.Events;
 using Serilog.Expressions.Ast;

--- a/src/Serilog.Expressions/Expressions/Compilation/Properties/PropertiesObjectAccessorTransformer.cs
+++ b/src/Serilog.Expressions/Expressions/Compilation/Properties/PropertiesObjectAccessorTransformer.cs
@@ -1,4 +1,18 @@
-﻿using Serilog.Expressions.Ast;
+﻿// Copyright © Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Serilog.Expressions.Ast;
 using Serilog.Expressions.Compilation.Transformations;
 
 namespace Serilog.Expressions.Compilation.Properties

--- a/src/Serilog.Expressions/Expressions/Compilation/Text/LikeSyntaxTransformer.cs
+++ b/src/Serilog.Expressions/Expressions/Compilation/Text/LikeSyntaxTransformer.cs
@@ -1,3 +1,17 @@
+// Copyright © Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 using System;
 using System.Text.RegularExpressions;
 using Serilog.Debugging;

--- a/src/Serilog.Expressions/Expressions/Compilation/Text/TextMatchingTransformer.cs
+++ b/src/Serilog.Expressions/Expressions/Compilation/Text/TextMatchingTransformer.cs
@@ -1,3 +1,17 @@
+// Copyright © Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 using System;
 using System.Text.RegularExpressions;
 using Serilog.Debugging;

--- a/src/Serilog.Expressions/Expressions/Compilation/Transformations/FilterExpressionTransformer`1.cs
+++ b/src/Serilog.Expressions/Expressions/Compilation/Transformations/FilterExpressionTransformer`1.cs
@@ -1,4 +1,18 @@
-﻿using System;
+﻿// Copyright © Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 using Serilog.Expressions.Ast;
 
 namespace Serilog.Expressions.Compilation.Transformations

--- a/src/Serilog.Expressions/Expressions/Compilation/Transformations/IdentityTransformer.cs
+++ b/src/Serilog.Expressions/Expressions/Compilation/Transformations/IdentityTransformer.cs
@@ -1,4 +1,18 @@
-﻿using System.Collections.Generic;
+﻿// Copyright © Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.Generic;
 using Serilog.Expressions.Ast;
 
 namespace Serilog.Expressions.Compilation.Transformations

--- a/src/Serilog.Expressions/Expressions/Compilation/Transformations/NodeReplacer.cs
+++ b/src/Serilog.Expressions/Expressions/Compilation/Transformations/NodeReplacer.cs
@@ -1,4 +1,18 @@
-﻿using Serilog.Expressions.Ast;
+﻿// Copyright © Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Serilog.Expressions.Ast;
 
 namespace Serilog.Expressions.Compilation.Transformations
 {

--- a/src/Serilog.Expressions/Expressions/Compilation/Variadics/VariadicCallRewriter.cs
+++ b/src/Serilog.Expressions/Expressions/Compilation/Variadics/VariadicCallRewriter.cs
@@ -1,3 +1,17 @@
+// Copyright © Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 using System.Linq;
 using Serilog.Expressions.Ast;
 using Serilog.Expressions.Compilation.Transformations;

--- a/src/Serilog.Expressions/Expressions/Compilation/Wildcards/WildcardComprehensionTransformer.cs
+++ b/src/Serilog.Expressions/Expressions/Compilation/Wildcards/WildcardComprehensionTransformer.cs
@@ -1,4 +1,18 @@
-﻿using System.Linq;
+﻿// Copyright © Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Linq;
 using Serilog.Expressions.Ast;
 using Serilog.Expressions.Compilation.Transformations;
 

--- a/src/Serilog.Expressions/Expressions/Compilation/Wildcards/WildcardSearch.cs
+++ b/src/Serilog.Expressions/Expressions/Compilation/Wildcards/WildcardSearch.cs
@@ -1,4 +1,18 @@
-﻿using System.Linq;
+﻿// Copyright © Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Linq;
 using Serilog.Expressions.Ast;
 using Serilog.Expressions.Compilation.Transformations;
 

--- a/src/Serilog.Expressions/Expressions/Evaluatable.cs
+++ b/src/Serilog.Expressions/Expressions/Evaluatable.cs
@@ -1,4 +1,18 @@
-﻿using Serilog.Events;
+﻿// Copyright © Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Serilog.Events;
 
 namespace Serilog.Expressions
 {

--- a/src/Serilog.Expressions/Expressions/EvaluationContext.cs
+++ b/src/Serilog.Expressions/Expressions/EvaluationContext.cs
@@ -1,4 +1,18 @@
-﻿using System;
+﻿// Copyright © Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 using Serilog.Events;
 using Serilog.Expressions.Runtime;
 

--- a/src/Serilog.Expressions/Expressions/NameResolver.cs
+++ b/src/Serilog.Expressions/Expressions/NameResolver.cs
@@ -32,7 +32,8 @@ namespace Serilog.Expressions
         /// <returns><c>True</c> if the name could be resolved; otherwise, <c>false</c>.</returns>
         /// <remarks>The method implementing a function should be <c>static</c>, return <see cref="LogEventPropertyValue"/>,
         /// and accept parameters of type <see cref="LogEventPropertyValue"/>. If the <c>ci</c> modifier is supported,
-        /// a <see cref="StringComparison"/> should be in the first argument position.</remarks>
+        /// a <see cref="StringComparison"/> should be included in the argument list. If the function is culture-specific,
+        /// an <see cref="IFormatProvider"/> should be included in the argument list.</remarks>
         public abstract bool TryResolveFunctionName(string name, [MaybeNullWhen(false)] out MethodInfo implementation);
     }
 }

--- a/src/Serilog.Expressions/Expressions/NameResolver.cs
+++ b/src/Serilog.Expressions/Expressions/NameResolver.cs
@@ -1,4 +1,18 @@
-﻿using System;
+﻿// Copyright © Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using Serilog.Events;

--- a/src/Serilog.Expressions/Expressions/Operators.cs
+++ b/src/Serilog.Expressions/Expressions/Operators.cs
@@ -1,4 +1,18 @@
-﻿using System;
+﻿// Copyright © Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 using System.Collections.Generic;
 using Serilog.Expressions.Ast;
 

--- a/src/Serilog.Expressions/Expressions/Operators.cs
+++ b/src/Serilog.Expressions/Expressions/Operators.cs
@@ -16,7 +16,7 @@ using System;
 using System.Collections.Generic;
 using Serilog.Expressions.Ast;
 
-// ReSharper disable MemberCanBePrivate.Global
+// ReSharper disable InconsistentNaming, MemberCanBePrivate.Global
 
 namespace Serilog.Expressions
 {

--- a/src/Serilog.Expressions/Expressions/Parsing/Combinators.cs
+++ b/src/Serilog.Expressions/Expressions/Parsing/Combinators.cs
@@ -1,4 +1,18 @@
-﻿using System;
+﻿// Copyright © Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 using Serilog.ParserConstruction;
 using Serilog.ParserConstruction.Model;
 

--- a/src/Serilog.Expressions/Expressions/Parsing/ExpressionKeyword.cs
+++ b/src/Serilog.Expressions/Expressions/Parsing/ExpressionKeyword.cs
@@ -1,4 +1,18 @@
-﻿using System;
+﻿// Copyright © Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 
 namespace Serilog.Expressions.Parsing
 {

--- a/src/Serilog.Expressions/Expressions/Parsing/ExpressionParser.cs
+++ b/src/Serilog.Expressions/Expressions/Parsing/ExpressionParser.cs
@@ -1,4 +1,18 @@
-﻿using System;
+﻿// Copyright © Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 using System.Diagnostics.CodeAnalysis;
 using Serilog.Expressions.Ast;
 

--- a/src/Serilog.Expressions/Expressions/Parsing/ExpressionTextParsers.cs
+++ b/src/Serilog.Expressions/Expressions/Parsing/ExpressionTextParsers.cs
@@ -1,4 +1,18 @@
-﻿using Serilog.ParserConstruction;
+﻿// Copyright © Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Serilog.ParserConstruction;
 using Serilog.ParserConstruction.Model;
 using Serilog.ParserConstruction.Parsers;
 

--- a/src/Serilog.Expressions/Expressions/Parsing/ExpressionToken.cs
+++ b/src/Serilog.Expressions/Expressions/Parsing/ExpressionToken.cs
@@ -1,4 +1,18 @@
-﻿using Serilog.ParserConstruction.Display;
+﻿// Copyright © Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Serilog.ParserConstruction.Display;
 
 namespace Serilog.Expressions.Parsing
 {

--- a/src/Serilog.Expressions/Expressions/Parsing/ExpressionTokenParsers.cs
+++ b/src/Serilog.Expressions/Expressions/Parsing/ExpressionTokenParsers.cs
@@ -1,4 +1,18 @@
-﻿using System;
+﻿// Copyright © Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 using System.Globalization;
 using System.Linq;
 using Serilog.Events;

--- a/src/Serilog.Expressions/Expressions/Parsing/ExpressionTokenizer.cs
+++ b/src/Serilog.Expressions/Expressions/Parsing/ExpressionTokenizer.cs
@@ -1,4 +1,18 @@
-﻿using System.Collections.Generic;
+﻿// Copyright © Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.Generic;
 using System.Linq;
 using Serilog.ParserConstruction;
 using Serilog.ParserConstruction.Model;

--- a/src/Serilog.Expressions/Expressions/Parsing/ParserExtensions.cs
+++ b/src/Serilog.Expressions/Expressions/Parsing/ParserExtensions.cs
@@ -1,4 +1,18 @@
-﻿using System;
+﻿// Copyright © Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 using Serilog.ParserConstruction;
 using Serilog.ParserConstruction.Model;
 

--- a/src/Serilog.Expressions/Expressions/Runtime/Coerce.cs
+++ b/src/Serilog.Expressions/Expressions/Runtime/Coerce.cs
@@ -1,3 +1,17 @@
+// Copyright © Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;

--- a/src/Serilog.Expressions/Expressions/Runtime/Locals.cs
+++ b/src/Serilog.Expressions/Expressions/Runtime/Locals.cs
@@ -1,4 +1,18 @@
-﻿using System.Diagnostics.CodeAnalysis;
+﻿// Copyright © Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Diagnostics.CodeAnalysis;
 using Serilog.Events;
 
 namespace Serilog.Expressions.Runtime

--- a/src/Serilog.Expressions/Expressions/Runtime/RuntimeOperators.cs
+++ b/src/Serilog.Expressions/Expressions/Runtime/RuntimeOperators.cs
@@ -423,18 +423,18 @@ namespace Serilog.Expressions.Runtime
 
         public static LogEventPropertyValue _Internal_IsNull(LogEventPropertyValue? value)
         {
-            return ScalarBoolean(value is null || value is ScalarValue sv && sv.Value == null);
+            return ScalarBoolean(value is null or ScalarValue {Value: null});
         }
 
         public static LogEventPropertyValue _Internal_IsNotNull(LogEventPropertyValue? value)
         {
-            return ScalarBoolean(!(value is null || value is ScalarValue sv && sv.Value == null));
+            return ScalarBoolean(value is not (null or ScalarValue {Value: null}));
         }
 
         // Ideally this will be compiled as a short-circuiting intrinsic
         public static LogEventPropertyValue? Coalesce(LogEventPropertyValue? v1, LogEventPropertyValue? v2)
         {
-            if (v1 is null || v1 is ScalarValue sv && sv.Value == null)
+            if (v1 is null or ScalarValue {Value: null})
                 return v2;
 
             return v1;
@@ -482,7 +482,7 @@ namespace Serilog.Expressions.Runtime
             return Coerce.IsTrue(condition) ? consequent : alternative;
         }
 
-        public static LogEventPropertyValue? ToString(LogEventPropertyValue? value, LogEventPropertyValue? format)
+        public static LogEventPropertyValue? ToString(IFormatProvider? formatProvider, LogEventPropertyValue? value, LogEventPropertyValue? format)
         {
             if (value is not ScalarValue sv ||
                 sv.Value == null ||
@@ -494,8 +494,7 @@ namespace Serilog.Expressions.Runtime
             string? toString;
             if (sv.Value is IFormattable formattable)
             {
-                // TODO #19: formatting is culture-specific.
-                toString = formattable.ToString(fmt, null);
+                toString = formattable.ToString(fmt, formatProvider);
             }
             else
             {

--- a/src/Serilog.Expressions/Expressions/Runtime/RuntimeOperators.cs
+++ b/src/Serilog.Expressions/Expressions/Runtime/RuntimeOperators.cs
@@ -1,4 +1,18 @@
-﻿using System;
+﻿// Copyright © Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Serilog.Events;

--- a/src/Serilog.Expressions/Expressions/StaticMemberNameResolver.cs
+++ b/src/Serilog.Expressions/Expressions/StaticMemberNameResolver.cs
@@ -1,4 +1,18 @@
-﻿using System;
+﻿// Copyright © Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;

--- a/src/Serilog.Expressions/LoggerFilterConfigurationExtensions.cs
+++ b/src/Serilog.Expressions/LoggerFilterConfigurationExtensions.cs
@@ -1,4 +1,18 @@
-﻿using System;
+﻿// Copyright © Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 using Serilog.Configuration;
 using Serilog.Expressions;
 using Serilog.Expressions.Runtime;

--- a/src/Serilog.Expressions/Pipeline/ComputedPropertyEnricher.cs
+++ b/src/Serilog.Expressions/Pipeline/ComputedPropertyEnricher.cs
@@ -1,3 +1,17 @@
+// Copyright © Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 using System;
 using Serilog.Core;
 using Serilog.Events;

--- a/src/Serilog.Expressions/Templates/Ast/Conditional.cs
+++ b/src/Serilog.Expressions/Templates/Ast/Conditional.cs
@@ -1,4 +1,18 @@
-﻿using System;
+﻿// Copyright © Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 using Serilog.Expressions.Ast;
 
 namespace Serilog.Templates.Ast

--- a/src/Serilog.Expressions/Templates/Ast/FormattedExpression.cs
+++ b/src/Serilog.Expressions/Templates/Ast/FormattedExpression.cs
@@ -1,3 +1,17 @@
+// Copyright © Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 using System;
 using Serilog.Expressions.Ast;
 using Serilog.Parsing;

--- a/src/Serilog.Expressions/Templates/Ast/LiteralText.cs
+++ b/src/Serilog.Expressions/Templates/Ast/LiteralText.cs
@@ -1,3 +1,17 @@
+// Copyright © Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 using System;
 
 namespace Serilog.Templates.Ast

--- a/src/Serilog.Expressions/Templates/Ast/Repetition.cs
+++ b/src/Serilog.Expressions/Templates/Ast/Repetition.cs
@@ -1,4 +1,18 @@
-﻿using System;
+﻿// Copyright © Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 using Serilog.Expressions.Ast;
 
 namespace Serilog.Templates.Ast

--- a/src/Serilog.Expressions/Templates/Ast/Template.cs
+++ b/src/Serilog.Expressions/Templates/Ast/Template.cs
@@ -1,3 +1,17 @@
+// Copyright © Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 namespace Serilog.Templates.Ast
 {
     abstract class Template

--- a/src/Serilog.Expressions/Templates/Ast/TemplateBlock.cs
+++ b/src/Serilog.Expressions/Templates/Ast/TemplateBlock.cs
@@ -1,3 +1,17 @@
+// Copyright © Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 using System;
 
 namespace Serilog.Templates.Ast

--- a/src/Serilog.Expressions/Templates/Compilation/CompiledConditional.cs
+++ b/src/Serilog.Expressions/Templates/Compilation/CompiledConditional.cs
@@ -1,8 +1,20 @@
-﻿using System;
+﻿// Copyright © Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 using System.IO;
-using Serilog.Events;
 using Serilog.Expressions;
-using Serilog.Templates.Themes;
 
 namespace Serilog.Templates.Compilation
 {

--- a/src/Serilog.Expressions/Templates/Compilation/CompiledConditional.cs
+++ b/src/Serilog.Expressions/Templates/Compilation/CompiledConditional.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using Serilog.Events;
 using Serilog.Expressions;
+using Serilog.Templates.Themes;
 
 namespace Serilog.Templates.Compilation
 {

--- a/src/Serilog.Expressions/Templates/Compilation/CompiledConditional.cs
+++ b/src/Serilog.Expressions/Templates/Compilation/CompiledConditional.cs
@@ -19,12 +19,12 @@ namespace Serilog.Templates.Compilation
             _alternative = alternative;
         }
 
-        public override void Evaluate(EvaluationContext ctx, TextWriter output, IFormatProvider? formatProvider)
+        public override void Evaluate(EvaluationContext ctx, TextWriter output)
         {
             if (ExpressionResult.IsTrue(_condition.Invoke(ctx)))
-                _consequent.Evaluate(ctx, output, formatProvider);
+                _consequent.Evaluate(ctx, output);
             else
-                _alternative?.Evaluate(ctx, output, formatProvider);
+                _alternative?.Evaluate(ctx, output);
         }
     }
 }

--- a/src/Serilog.Expressions/Templates/Compilation/CompiledExceptionToken.cs
+++ b/src/Serilog.Expressions/Templates/Compilation/CompiledExceptionToken.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.IO;
+﻿using System.IO;
 using Serilog.Expressions;
 using Serilog.Templates.Themes;
 
@@ -17,7 +16,7 @@ namespace Serilog.Templates.Compilation
             _secondaryText = theme.GetStyle(TemplateThemeStyle.SecondaryText);
         }
 
-        public override void Evaluate(EvaluationContext ctx, TextWriter output, IFormatProvider? formatProvider)
+        public override void Evaluate(EvaluationContext ctx, TextWriter output)
         {
             // Padding and alignment are not applied by this renderer.
 

--- a/src/Serilog.Expressions/Templates/Compilation/CompiledExceptionToken.cs
+++ b/src/Serilog.Expressions/Templates/Compilation/CompiledExceptionToken.cs
@@ -1,4 +1,18 @@
-﻿using System.IO;
+﻿// Copyright © Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.IO;
 using Serilog.Expressions;
 using Serilog.Templates.Themes;
 

--- a/src/Serilog.Expressions/Templates/Compilation/CompiledExceptionToken.cs
+++ b/src/Serilog.Expressions/Templates/Compilation/CompiledExceptionToken.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.IO;
+using Serilog.Expressions;
+using Serilog.Templates.Themes;
+
+namespace Serilog.Templates.Compilation
+{
+    class CompiledExceptionToken : CompiledTemplate
+    {
+        const string StackFrameLinePrefix = "   ";
+
+        readonly Style _text, _secondaryText;
+        
+        public CompiledExceptionToken(TemplateTheme theme)
+        {
+            _text = theme.GetStyle(TemplateThemeStyle.Text);
+            _secondaryText = theme.GetStyle(TemplateThemeStyle.SecondaryText);
+        }
+
+        public override void Evaluate(EvaluationContext ctx, TextWriter output, IFormatProvider? formatProvider)
+        {
+            // Padding and alignment are not applied by this renderer.
+
+            if (ctx.LogEvent.Exception is null)
+                return;
+
+            var lines = new StringReader(ctx.LogEvent.Exception.ToString());
+            string? nextLine;
+            while ((nextLine = lines.ReadLine()) != null)
+            {
+                var style = nextLine.StartsWith(StackFrameLinePrefix) ? _secondaryText : _text;
+                var _ = 0;
+                using (style.Set(output, ref _))
+                    output.WriteLine(nextLine);
+            }
+        }
+    }
+}

--- a/src/Serilog.Expressions/Templates/Compilation/CompiledFormattedExpression.cs
+++ b/src/Serilog.Expressions/Templates/Compilation/CompiledFormattedExpression.cs
@@ -14,29 +14,31 @@ namespace Serilog.Templates.Compilation
         readonly Evaluatable _expression;
         readonly string? _format;
         readonly Alignment? _alignment;
+        readonly IFormatProvider? _formatProvider;
         readonly Style _secondaryText;
 
-        public CompiledFormattedExpression(Evaluatable expression, string? format, Alignment? alignment, TemplateTheme theme)
+        public CompiledFormattedExpression(Evaluatable expression, string? format, Alignment? alignment, IFormatProvider? formatProvider, TemplateTheme theme)
         {
             _expression = expression ?? throw new ArgumentNullException(nameof(expression));
             _format = format;
             _alignment = alignment;
+            _formatProvider = formatProvider;
             _secondaryText = theme.GetStyle(TemplateThemeStyle.SecondaryText);
             _jsonFormatter = new ThemedJsonValueFormatter(theme);
         }
 
-        public override void Evaluate(EvaluationContext ctx, TextWriter output, IFormatProvider? formatProvider)
+        public override void Evaluate(EvaluationContext ctx, TextWriter output)
         {
             var invisibleCharacterCount = 0;
             
             if (_alignment == null)
             {
-                EvaluateUnaligned(ctx, output, formatProvider, ref invisibleCharacterCount);
+                EvaluateUnaligned(ctx, output, _formatProvider, ref invisibleCharacterCount);
             }
             else
             {
                 var writer = new StringWriter();
-                EvaluateUnaligned(ctx, writer, formatProvider, ref invisibleCharacterCount);
+                EvaluateUnaligned(ctx, writer, _formatProvider, ref invisibleCharacterCount);
                 Padding.Apply(output, writer.ToString(), _alignment.Value.Widen(invisibleCharacterCount));
             }
         }

--- a/src/Serilog.Expressions/Templates/Compilation/CompiledFormattedExpression.cs
+++ b/src/Serilog.Expressions/Templates/Compilation/CompiledFormattedExpression.cs
@@ -16,29 +16,35 @@ namespace Serilog.Templates.Compilation
         readonly Evaluatable _expression;
         readonly string? _format;
         readonly Alignment? _alignment;
+        readonly TemplateTheme _theme;
+        readonly Style _secondaryText;
 
-        public CompiledFormattedExpression(Evaluatable expression, string? format, Alignment? alignment)
+        public CompiledFormattedExpression(Evaluatable expression, string? format, Alignment? alignment, TemplateTheme theme)
         {
             _expression = expression ?? throw new ArgumentNullException(nameof(expression));
             _format = format;
             _alignment = alignment;
+            _theme = theme;
+            _secondaryText = theme.GetStyle(TemplateThemeStyle.SecondaryText);
         }
 
         public override void Evaluate(EvaluationContext ctx, TextWriter output, IFormatProvider? formatProvider)
         {
+            var invisibleCharacterCount = 0;
+            
             if (_alignment == null)
             {
-                EvaluateUnaligned(ctx, output, formatProvider);
+                EvaluateUnaligned(ctx, output, formatProvider, ref invisibleCharacterCount);
             }
             else
             {
                 var writer = new StringWriter();
-                EvaluateUnaligned(ctx, writer, formatProvider);
-                Padding.Apply(output, writer.ToString(), _alignment.Value);
+                EvaluateUnaligned(ctx, writer, formatProvider, ref invisibleCharacterCount);
+                Padding.Apply(output, writer.ToString(), _alignment.Value.Widen(invisibleCharacterCount));
             }
         }
         
-        void EvaluateUnaligned(EvaluationContext ctx, TextWriter output, IFormatProvider? formatProvider)
+        void EvaluateUnaligned(EvaluationContext ctx, TextWriter output, IFormatProvider? formatProvider, ref int invisibleCharacterCount)
         {
             var value = _expression(ctx);
             if (value == null)
@@ -49,10 +55,9 @@ namespace Serilog.Templates.Compilation
                 if (scalar.Value is null)
                     return; // Null is empty
 
-                if (scalar.Value is LogEventLevel level)
-                    // This would be better implemented using CompiledLevelToken : CompiledTemplate.
-                    output.Write(LevelRenderer.GetLevelMoniker(level, _format));
-                else if (scalar.Value is IFormattable fmt)
+                using var style = _secondaryText.Set(output, ref invisibleCharacterCount);
+                
+                if (scalar.Value is IFormattable fmt)
                     output.Write(fmt.ToString(_format, formatProvider));
                 else
                     output.Write(scalar.Value.ToString());

--- a/src/Serilog.Expressions/Templates/Compilation/CompiledFormattedExpression.cs
+++ b/src/Serilog.Expressions/Templates/Compilation/CompiledFormattedExpression.cs
@@ -2,7 +2,6 @@ using System;
 using System.IO;
 using Serilog.Events;
 using Serilog.Expressions;
-using Serilog.Formatting.Json;
 using Serilog.Parsing;
 using Serilog.Templates.Rendering;
 using Serilog.Templates.Themes;
@@ -11,12 +10,10 @@ namespace Serilog.Templates.Compilation
 {
     class CompiledFormattedExpression : CompiledTemplate
     {
-        static readonly JsonValueFormatter JsonFormatter = new("$type");
-        
+        readonly ThemedJsonValueFormatter _jsonFormatter;
         readonly Evaluatable _expression;
         readonly string? _format;
         readonly Alignment? _alignment;
-        readonly TemplateTheme _theme;
         readonly Style _secondaryText;
 
         public CompiledFormattedExpression(Evaluatable expression, string? format, Alignment? alignment, TemplateTheme theme)
@@ -24,8 +21,8 @@ namespace Serilog.Templates.Compilation
             _expression = expression ?? throw new ArgumentNullException(nameof(expression));
             _format = format;
             _alignment = alignment;
-            _theme = theme;
             _secondaryText = theme.GetStyle(TemplateThemeStyle.SecondaryText);
+            _jsonFormatter = new ThemedJsonValueFormatter(theme);
         }
 
         public override void Evaluate(EvaluationContext ctx, TextWriter output, IFormatProvider? formatProvider)
@@ -64,7 +61,7 @@ namespace Serilog.Templates.Compilation
             }
             else
             {
-                JsonFormatter.Format(value, output);
+                invisibleCharacterCount += _jsonFormatter.Format(value, output);
             }
         }
     }

--- a/src/Serilog.Expressions/Templates/Compilation/CompiledFormattedExpression.cs
+++ b/src/Serilog.Expressions/Templates/Compilation/CompiledFormattedExpression.cs
@@ -1,3 +1,17 @@
+// Copyright © Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 using System;
 using System.IO;
 using Serilog.Events;

--- a/src/Serilog.Expressions/Templates/Compilation/CompiledFormattedExpression.cs
+++ b/src/Serilog.Expressions/Templates/Compilation/CompiledFormattedExpression.cs
@@ -5,12 +5,13 @@ using Serilog.Expressions;
 using Serilog.Formatting.Json;
 using Serilog.Parsing;
 using Serilog.Templates.Rendering;
+using Serilog.Templates.Themes;
 
 namespace Serilog.Templates.Compilation
 {
     class CompiledFormattedExpression : CompiledTemplate
     {
-        static readonly JsonValueFormatter JsonFormatter = new JsonValueFormatter("$type");
+        static readonly JsonValueFormatter JsonFormatter = new("$type");
         
         readonly Evaluatable _expression;
         readonly string? _format;

--- a/src/Serilog.Expressions/Templates/Compilation/CompiledLevelToken.cs
+++ b/src/Serilog.Expressions/Templates/Compilation/CompiledLevelToken.cs
@@ -1,4 +1,18 @@
-﻿using System.IO;
+﻿// Copyright © Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.IO;
 using Serilog.Expressions;
 using Serilog.Parsing;
 using Serilog.Templates.Rendering;

--- a/src/Serilog.Expressions/Templates/Compilation/CompiledLevelToken.cs
+++ b/src/Serilog.Expressions/Templates/Compilation/CompiledLevelToken.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.IO;
+using Serilog.Expressions;
+using Serilog.Parsing;
+using Serilog.Templates.Rendering;
+using Serilog.Templates.Themes;
+
+namespace Serilog.Templates.Compilation
+{
+    class CompiledLevelToken : CompiledTemplate
+    {
+        readonly string? _format;
+        readonly Alignment? _alignment;
+        readonly Style[] _levelStyles;
+
+        public CompiledLevelToken(string? format, Alignment? alignment, TemplateTheme theme)
+        {
+            _format = format;
+            _alignment = alignment;
+            _levelStyles = new[]
+            {
+                theme.GetStyle(TemplateThemeStyle.LevelVerbose),
+                theme.GetStyle(TemplateThemeStyle.LevelDebug),
+                theme.GetStyle(TemplateThemeStyle.LevelInformation),
+                theme.GetStyle(TemplateThemeStyle.LevelWarning),
+                theme.GetStyle(TemplateThemeStyle.LevelError),
+                theme.GetStyle(TemplateThemeStyle.LevelFatal),
+            };
+        }
+
+        public override void Evaluate(EvaluationContext ctx, TextWriter output, IFormatProvider? formatProvider)
+        {
+            var invisibleCharacterCount = 0;
+            
+            if (_alignment == null)
+            {
+                EvaluateUnaligned(ctx, output, ref invisibleCharacterCount);
+            }
+            else
+            {
+                var writer = new StringWriter();
+                EvaluateUnaligned(ctx, writer, ref invisibleCharacterCount);
+                Padding.Apply(output, writer.ToString(), _alignment.Value.Widen(invisibleCharacterCount));
+            }
+        }
+        
+        void EvaluateUnaligned(EvaluationContext ctx, TextWriter output, ref int invisibleCharacterCount)
+        {
+            var levelIndex = (int) ctx.LogEvent.Level;
+            if (levelIndex < 0 || levelIndex >= _levelStyles.Length)
+                return;
+            
+            using var _ = _levelStyles[levelIndex].Set(output, ref invisibleCharacterCount);
+            output.Write(LevelRenderer.GetLevelMoniker(ctx.LogEvent.Level, _format));
+        }
+    }
+}

--- a/src/Serilog.Expressions/Templates/Compilation/CompiledLevelToken.cs
+++ b/src/Serilog.Expressions/Templates/Compilation/CompiledLevelToken.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.IO;
+﻿using System.IO;
 using Serilog.Expressions;
 using Serilog.Parsing;
 using Serilog.Templates.Rendering;
@@ -28,7 +27,7 @@ namespace Serilog.Templates.Compilation
             };
         }
 
-        public override void Evaluate(EvaluationContext ctx, TextWriter output, IFormatProvider? formatProvider)
+        public override void Evaluate(EvaluationContext ctx, TextWriter output)
         {
             var invisibleCharacterCount = 0;
             

--- a/src/Serilog.Expressions/Templates/Compilation/CompiledLiteralText.cs
+++ b/src/Serilog.Expressions/Templates/Compilation/CompiledLiteralText.cs
@@ -16,7 +16,7 @@ namespace Serilog.Templates.Compilation
             _style = theme.GetStyle(TemplateThemeStyle.TertiaryText);
         }
 
-        public override void Evaluate(EvaluationContext ctx, TextWriter output, IFormatProvider? formatProvider)
+        public override void Evaluate(EvaluationContext ctx, TextWriter output)
         {
             var _ = 0;
             using (_style.Set(output, ref _))

--- a/src/Serilog.Expressions/Templates/Compilation/CompiledLiteralText.cs
+++ b/src/Serilog.Expressions/Templates/Compilation/CompiledLiteralText.cs
@@ -1,3 +1,17 @@
+// Copyright © Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 using System;
 using System.IO;
 using Serilog.Expressions;

--- a/src/Serilog.Expressions/Templates/Compilation/CompiledLiteralText.cs
+++ b/src/Serilog.Expressions/Templates/Compilation/CompiledLiteralText.cs
@@ -1,22 +1,26 @@
 using System;
 using System.IO;
-using Serilog.Events;
 using Serilog.Expressions;
+using Serilog.Templates.Themes;
 
 namespace Serilog.Templates.Compilation
 {
     class CompiledLiteralText : CompiledTemplate
     {
         readonly string _text;
+        readonly Style _style;
 
-        public CompiledLiteralText(string text)
+        public CompiledLiteralText(string text, TemplateTheme theme)
         {
             _text = text ?? throw new ArgumentNullException(nameof(text));
+            _style = theme.GetStyle(TemplateThemeStyle.TertiaryText);
         }
 
         public override void Evaluate(EvaluationContext ctx, TextWriter output, IFormatProvider? formatProvider)
         {
-            output.Write(_text);
+            var _ = 0;
+            using (_style.Set(output, ref _))
+                output.Write(_text);
         }
     }
 }

--- a/src/Serilog.Expressions/Templates/Compilation/CompiledMessageToken.cs
+++ b/src/Serilog.Expressions/Templates/Compilation/CompiledMessageToken.cs
@@ -1,0 +1,170 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using Serilog.Events;
+using Serilog.Expressions;
+using Serilog.Parsing;
+using Serilog.Templates.Rendering;
+using Serilog.Templates.Themes;
+
+namespace Serilog.Templates.Compilation
+{
+    class CompiledMessageToken : CompiledTemplate
+    {
+        readonly IFormatProvider? _formatProvider;
+        readonly Alignment? _alignment;
+        readonly Style _text, _invalid, _null, _bool, _string, _num, _scalar;
+        readonly ThemedJsonValueFormatter _jsonFormatter;
+
+        public CompiledMessageToken(IFormatProvider? formatProvider, Alignment? alignment, TemplateTheme theme)
+        {
+            _formatProvider = formatProvider;
+            _alignment = alignment;
+            _text = theme.GetStyle(TemplateThemeStyle.Text);
+            _null = theme.GetStyle(TemplateThemeStyle.Null);
+            _bool = theme.GetStyle(TemplateThemeStyle.Boolean);
+            _num = theme.GetStyle(TemplateThemeStyle.Number);
+            _string = theme.GetStyle(TemplateThemeStyle.String);
+            _scalar = theme.GetStyle(TemplateThemeStyle.Scalar);
+            _invalid = theme.GetStyle(TemplateThemeStyle.Invalid);
+            _jsonFormatter = new ThemedJsonValueFormatter(theme);
+        }
+
+        public override void Evaluate(EvaluationContext ctx, TextWriter output)
+        {
+            var invisibleCharacterCount = 0;
+            
+            if (_alignment == null)
+            {
+                EvaluateUnaligned(ctx, output, ref invisibleCharacterCount);
+            }
+            else
+            {
+                var writer = new StringWriter();
+                EvaluateUnaligned(ctx, writer, ref invisibleCharacterCount);
+                Padding.Apply(output, writer.ToString(), _alignment.Value.Widen(invisibleCharacterCount));
+            }
+        }
+        
+        void EvaluateUnaligned(EvaluationContext ctx, TextWriter output, ref int invisibleCharacterCount)
+        {
+            foreach (var token in ctx.LogEvent.MessageTemplate.Tokens)
+            {
+                switch (token)
+                {
+                    case TextToken tt:
+                    {
+                        using var _ = _text.Set(output, ref invisibleCharacterCount);
+                        output.Write(tt.Text);
+                        break;
+                    }
+                    case PropertyToken pt:
+                    {
+                        EvaluateProperty(ctx.LogEvent.Properties, pt, output, ref invisibleCharacterCount);
+                        break;
+                    }
+                    default:
+                    {
+                        output.Write(token);
+                        break;
+                    }
+                }
+            }
+        }
+
+        void EvaluateProperty(IReadOnlyDictionary<string,LogEventPropertyValue> properties, PropertyToken pt, TextWriter output, ref int invisibleCharacterCount)
+        {
+            if (!properties.TryGetValue(pt.PropertyName, out var value))
+            {
+                using var _ = _invalid.Set(output, ref invisibleCharacterCount);
+                output.Write(pt.ToString());
+                return;
+            }
+            
+            if (pt.Alignment is null)
+            {
+                EvaluatePropertyUnaligned(value, output, pt.Format, ref invisibleCharacterCount);
+                return;
+            }
+
+            var buffer = new StringWriter();
+            var resultInvisibleCharacters = 0;
+            
+            EvaluatePropertyUnaligned(value, buffer, pt.Format, ref resultInvisibleCharacters);
+            
+            var result = buffer.ToString();
+            invisibleCharacterCount += resultInvisibleCharacters;
+
+            if (result.Length - resultInvisibleCharacters >= pt.Alignment.Value.Width)
+                output.Write(result);
+            else
+                Padding.Apply(output, result, pt.Alignment.Value.Widen(resultInvisibleCharacters));
+        }
+
+        void EvaluatePropertyUnaligned(LogEventPropertyValue propertyValue, TextWriter output, string? format, ref int invisibleCharacterCount)
+        {
+            if (propertyValue is not ScalarValue scalar)
+            {
+                invisibleCharacterCount += _jsonFormatter.Format(propertyValue, output);
+                return;
+            }
+            
+            var value = scalar.Value;
+
+            if (value == null)
+            {
+                using (_null.Set(output, ref invisibleCharacterCount))
+                    output.Write("null");
+                return;
+            }
+
+            if (value is string str)
+            {
+                using (_string.Set(output, ref invisibleCharacterCount))
+                    output.Write(str);
+                return;
+            }
+
+            if (value is ValueType)
+            {
+                if (value is int or uint or long or ulong or decimal or byte or sbyte or short or ushort)
+                {
+                    using (_num.Set(output, ref invisibleCharacterCount))
+                        output.Write(((IFormattable)value).ToString(format, _formatProvider));
+                    return;
+                }
+
+                if (value is double d)
+                {
+                    using (_num.Set(output, ref invisibleCharacterCount))
+                        output.Write(d.ToString(format, _formatProvider));
+                    return;
+                }
+
+                if (value is float f)
+                {
+                    using (_num.Set(output, ref invisibleCharacterCount))
+                        output.Write(f.ToString(format, _formatProvider));
+                    return;
+                }
+
+                if (value is bool b)
+                {
+                    using (_bool.Set(output, ref invisibleCharacterCount))
+                        output.Write(b);
+                    return;
+                }
+            }
+
+            if (value is IFormattable formattable)
+            {
+                using (_scalar.Set(output, ref invisibleCharacterCount))
+                    output.Write(formattable.ToString(format, _formatProvider));
+                return;
+            }
+
+            using (_scalar.Set(output, ref invisibleCharacterCount))
+                output.Write(value);
+        }
+    }
+}

--- a/src/Serilog.Expressions/Templates/Compilation/CompiledMessageToken.cs
+++ b/src/Serilog.Expressions/Templates/Compilation/CompiledMessageToken.cs
@@ -1,4 +1,18 @@
-﻿using System;
+﻿// Copyright © Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using Serilog.Events;

--- a/src/Serilog.Expressions/Templates/Compilation/CompiledRepetition.cs
+++ b/src/Serilog.Expressions/Templates/Compilation/CompiledRepetition.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.IO;
+﻿using System.IO;
 using Serilog.Events;
 using Serilog.Expressions;
 using Serilog.Expressions.Runtime;
@@ -31,13 +30,13 @@ namespace Serilog.Templates.Compilation
             _alternative = alternative;
         }
 
-        public override void Evaluate(EvaluationContext ctx, TextWriter output, IFormatProvider? formatProvider)
+        public override void Evaluate(EvaluationContext ctx, TextWriter output)
         {
             var enumerable = _enumerable(ctx);
             if (enumerable == null ||
                 enumerable is ScalarValue)
             {
-                _alternative?.Evaluate(ctx, output, formatProvider);
+                _alternative?.Evaluate(ctx, output);
                 return;
             }
 
@@ -45,7 +44,7 @@ namespace Serilog.Templates.Compilation
             {
                 if (sv.Elements.Count == 0)
                 {
-                    _alternative?.Evaluate(ctx, output, formatProvider);
+                    _alternative?.Evaluate(ctx, output);
                     return;
                 }
 
@@ -58,13 +57,13 @@ namespace Serilog.Templates.Compilation
                     if (first)
                         first = false;
                     else
-                        _delimiter?.Evaluate(ctx, output, formatProvider);
+                        _delimiter?.Evaluate(ctx, output);
 
                     var local = _keyOrElementName != null
                         ? new EvaluationContext(ctx.LogEvent, Locals.Set(ctx.Locals, _keyOrElementName, element))
                         : ctx;
                     
-                    _body.Evaluate(local, output, formatProvider);
+                    _body.Evaluate(local, output);
                 }
                 
                 return;
@@ -74,7 +73,7 @@ namespace Serilog.Templates.Compilation
             {
                 if (structure.Properties.Count == 0)
                 {
-                    _alternative?.Evaluate(ctx, output, formatProvider);
+                    _alternative?.Evaluate(ctx, output);
                     return;
                 }
 
@@ -84,7 +83,7 @@ namespace Serilog.Templates.Compilation
                     if (first)
                         first = false;
                     else
-                        _delimiter?.Evaluate(ctx, output, formatProvider);
+                        _delimiter?.Evaluate(ctx, output);
 
                     var local = _keyOrElementName != null
                         ? new EvaluationContext(ctx.LogEvent, Locals.Set(ctx.Locals, _keyOrElementName, new ScalarValue(member.Name)))
@@ -94,7 +93,7 @@ namespace Serilog.Templates.Compilation
                         ? new EvaluationContext(local.LogEvent, Locals.Set(local.Locals, _valueName, member.Value))
                         : local;
                     
-                    _body.Evaluate(local, output, formatProvider);
+                    _body.Evaluate(local, output);
                 }
             }
             
@@ -102,7 +101,7 @@ namespace Serilog.Templates.Compilation
             {
                 if (dict.Elements.Count == 0)
                 {
-                    _alternative?.Evaluate(ctx, output, formatProvider);
+                    _alternative?.Evaluate(ctx, output);
                     return;
                 }
 
@@ -112,7 +111,7 @@ namespace Serilog.Templates.Compilation
                     if (first)
                         first = false;
                     else
-                        _delimiter?.Evaluate(ctx, output, formatProvider);
+                        _delimiter?.Evaluate(ctx, output);
 
                     var local = _keyOrElementName != null
                         ? new EvaluationContext(ctx.LogEvent, Locals.Set(ctx.Locals, _keyOrElementName, element.Key))
@@ -122,7 +121,7 @@ namespace Serilog.Templates.Compilation
                         ? new EvaluationContext(local.LogEvent, Locals.Set(local.Locals, _valueName, element.Value))
                         : local;
                     
-                    _body.Evaluate(local, output, formatProvider);
+                    _body.Evaluate(local, output);
                 }
             }
             

--- a/src/Serilog.Expressions/Templates/Compilation/CompiledRepetition.cs
+++ b/src/Serilog.Expressions/Templates/Compilation/CompiledRepetition.cs
@@ -1,4 +1,18 @@
-﻿using System.IO;
+﻿// Copyright © Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.IO;
 using Serilog.Events;
 using Serilog.Expressions;
 using Serilog.Expressions.Runtime;

--- a/src/Serilog.Expressions/Templates/Compilation/CompiledTemplate.cs
+++ b/src/Serilog.Expressions/Templates/Compilation/CompiledTemplate.cs
@@ -1,6 +1,5 @@
 using System;
 using System.IO;
-using Serilog.Events;
 using Serilog.Expressions;
 
 namespace Serilog.Templates.Compilation

--- a/src/Serilog.Expressions/Templates/Compilation/CompiledTemplate.cs
+++ b/src/Serilog.Expressions/Templates/Compilation/CompiledTemplate.cs
@@ -1,4 +1,3 @@
-using System;
 using System.IO;
 using Serilog.Expressions;
 
@@ -6,6 +5,6 @@ namespace Serilog.Templates.Compilation
 {
     abstract class CompiledTemplate
     {
-        public abstract void Evaluate(EvaluationContext ctx, TextWriter output, IFormatProvider? formatProvider);
+        public abstract void Evaluate(EvaluationContext ctx, TextWriter output);
     }
 }

--- a/src/Serilog.Expressions/Templates/Compilation/CompiledTemplate.cs
+++ b/src/Serilog.Expressions/Templates/Compilation/CompiledTemplate.cs
@@ -1,3 +1,17 @@
+// Copyright © Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 using System.IO;
 using Serilog.Expressions;
 

--- a/src/Serilog.Expressions/Templates/Compilation/CompiledTemplateBlock.cs
+++ b/src/Serilog.Expressions/Templates/Compilation/CompiledTemplateBlock.cs
@@ -1,6 +1,5 @@
 using System;
 using System.IO;
-using Serilog.Events;
 using Serilog.Expressions;
 
 namespace Serilog.Templates.Compilation

--- a/src/Serilog.Expressions/Templates/Compilation/CompiledTemplateBlock.cs
+++ b/src/Serilog.Expressions/Templates/Compilation/CompiledTemplateBlock.cs
@@ -1,3 +1,17 @@
+// Copyright © Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 using System;
 using System.IO;
 using Serilog.Expressions;

--- a/src/Serilog.Expressions/Templates/Compilation/CompiledTemplateBlock.cs
+++ b/src/Serilog.Expressions/Templates/Compilation/CompiledTemplateBlock.cs
@@ -13,10 +13,10 @@ namespace Serilog.Templates.Compilation
             _elements = elements ?? throw new ArgumentNullException(nameof(elements));
         }
         
-        public override void Evaluate(EvaluationContext ctx, TextWriter output, IFormatProvider? formatProvider)
+        public override void Evaluate(EvaluationContext ctx, TextWriter output)
         {
             foreach (var element in _elements)
-                element.Evaluate(ctx, output, formatProvider);
+                element.Evaluate(ctx, output);
         }
     }
 }

--- a/src/Serilog.Expressions/Templates/Compilation/NameResolution/ExpressionLocalNameBinder.cs
+++ b/src/Serilog.Expressions/Templates/Compilation/NameResolution/ExpressionLocalNameBinder.cs
@@ -1,4 +1,18 @@
-﻿using System;
+﻿// Copyright © Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Serilog.Expressions.Ast;

--- a/src/Serilog.Expressions/Templates/Compilation/NameResolution/TemplateLocalNameResolver.cs
+++ b/src/Serilog.Expressions/Templates/Compilation/NameResolution/TemplateLocalNameResolver.cs
@@ -1,4 +1,18 @@
-﻿using System;
+﻿// Copyright © Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Serilog.Templates.Ast;

--- a/src/Serilog.Expressions/Templates/Compilation/TemplateCompiler.cs
+++ b/src/Serilog.Expressions/Templates/Compilation/TemplateCompiler.cs
@@ -3,31 +3,32 @@ using System.Linq;
 using Serilog.Expressions;
 using Serilog.Expressions.Compilation;
 using Serilog.Templates.Ast;
+using Serilog.Templates.Themes;
 
 namespace Serilog.Templates.Compilation
 {
     static class TemplateCompiler
     {
-        public static CompiledTemplate Compile(Template template, NameResolver nameResolver)
+        public static CompiledTemplate Compile(Template template, NameResolver nameResolver, TemplateTheme theme)
         {
             if (template == null) throw new ArgumentNullException(nameof(template));
             return template switch
             {
-                LiteralText text => new CompiledLiteralText(text.Text),
+                LiteralText text => new CompiledLiteralText(text.Text, theme),
                 FormattedExpression expression => new CompiledFormattedExpression(
                     ExpressionCompiler.Compile(expression.Expression, nameResolver), expression.Format, expression.Alignment),
-                TemplateBlock block => new CompiledTemplateBlock(block.Elements.Select(e => Compile(e, nameResolver)).ToArray()),
+                TemplateBlock block => new CompiledTemplateBlock(block.Elements.Select(e => Compile(e, nameResolver, theme)).ToArray()),
                 Conditional conditional => new CompiledConditional(
                     ExpressionCompiler.Compile(conditional.Condition, nameResolver),
-                    Compile(conditional.Consequent, nameResolver),
-                    conditional.Alternative == null ? null : Compile(conditional.Alternative, nameResolver)),
+                    Compile(conditional.Consequent, nameResolver, theme),
+                    conditional.Alternative == null ? null : Compile(conditional.Alternative, nameResolver, theme)),
                 Repetition repetition => new CompiledRepetition(
                     ExpressionCompiler.Compile(repetition.Enumerable, nameResolver),
                     repetition.BindingNames.Length > 0 ? repetition.BindingNames[0] : null,
                     repetition.BindingNames.Length > 1 ? repetition.BindingNames[1] : null,
-                    Compile(repetition.Body, nameResolver),
-                    repetition.Delimiter == null ? null : Compile(repetition.Delimiter, nameResolver),
-                    repetition.Alternative == null ? null : Compile(repetition.Alternative, nameResolver)),
+                    Compile(repetition.Body, nameResolver, theme),
+                    repetition.Delimiter == null ? null : Compile(repetition.Delimiter, nameResolver, theme),
+                    repetition.Alternative == null ? null : Compile(repetition.Alternative, nameResolver, theme)),
                 _ => throw new NotSupportedException()
             };
         }

--- a/src/Serilog.Expressions/Templates/Compilation/TemplateCompiler.cs
+++ b/src/Serilog.Expressions/Templates/Compilation/TemplateCompiler.cs
@@ -24,7 +24,9 @@ namespace Serilog.Templates.Compilation
 {
     static class TemplateCompiler
     {
-        public static CompiledTemplate Compile(Template template, IFormatProvider? formatProvider, NameResolver nameResolver, TemplateTheme theme)
+        public static CompiledTemplate Compile(Template template,
+            IFormatProvider? formatProvider, NameResolver nameResolver,
+            TemplateTheme theme)
         {
             return template switch
             {
@@ -43,14 +45,14 @@ namespace Serilog.Templates.Compilation
                     Format: null
                 } message => new CompiledMessageToken(formatProvider, message.Alignment, theme),
                 FormattedExpression expression => new CompiledFormattedExpression(
-                    ExpressionCompiler.Compile(expression.Expression, nameResolver), expression.Format, expression.Alignment, formatProvider, theme),
+                    ExpressionCompiler.Compile(expression.Expression, formatProvider, nameResolver), expression.Format, expression.Alignment, formatProvider, theme),
                 TemplateBlock block => new CompiledTemplateBlock(block.Elements.Select(e => Compile(e, formatProvider, nameResolver, theme)).ToArray()),
                 Conditional conditional => new CompiledConditional(
-                    ExpressionCompiler.Compile(conditional.Condition, nameResolver),
+                    ExpressionCompiler.Compile(conditional.Condition, formatProvider, nameResolver),
                     Compile(conditional.Consequent, formatProvider, nameResolver, theme),
                     conditional.Alternative == null ? null : Compile(conditional.Alternative, formatProvider, nameResolver, theme)),
                 Repetition repetition => new CompiledRepetition(
-                    ExpressionCompiler.Compile(repetition.Enumerable, nameResolver),
+                    ExpressionCompiler.Compile(repetition.Enumerable, formatProvider, nameResolver),
                     repetition.BindingNames.Length > 0 ? repetition.BindingNames[0] : null,
                     repetition.BindingNames.Length > 1 ? repetition.BindingNames[1] : null,
                     Compile(repetition.Body, formatProvider, nameResolver, theme),

--- a/src/Serilog.Expressions/Templates/Compilation/TemplateCompiler.cs
+++ b/src/Serilog.Expressions/Templates/Compilation/TemplateCompiler.cs
@@ -1,3 +1,17 @@
+// Copyright © Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 using System;
 using System.Linq;
 using Serilog.Expressions;

--- a/src/Serilog.Expressions/Templates/Compilation/TemplateCompiler.cs
+++ b/src/Serilog.Expressions/Templates/Compilation/TemplateCompiler.cs
@@ -10,24 +10,21 @@ namespace Serilog.Templates.Compilation
 {
     static class TemplateCompiler
     {
-        public static CompiledTemplate Compile(Template template, NameResolver nameResolver, TemplateTheme? theme)
+        public static CompiledTemplate Compile(Template template, NameResolver nameResolver, TemplateTheme theme)
         {
-            // Currently, the same implementations are used for themed and un-themed output; in future we could optimize
-            // here by choosing simpler variants when `theme` is `null`.
-            
             return template switch
             {
-                LiteralText text => new CompiledLiteralText(text.Text, theme ?? TemplateTheme.None),
+                LiteralText text => new CompiledLiteralText(text.Text, theme),
                 FormattedExpression { Expression: AmbientNameExpression { IsBuiltIn: true, PropertyName: BuiltInProperty.Level} } level => new CompiledLevelToken(
-                    level.Format, level.Alignment, theme ?? TemplateTheme.None),
+                    level.Format, level.Alignment, theme),
                 FormattedExpression
                 {
                     Expression: AmbientNameExpression { IsBuiltIn: true, PropertyName: BuiltInProperty.Exception }, 
                     Alignment: null,
                     Format: null
-                } => new CompiledExceptionToken(theme ?? TemplateTheme.None),
+                } => new CompiledExceptionToken(theme),
                 FormattedExpression expression => new CompiledFormattedExpression(
-                    ExpressionCompiler.Compile(expression.Expression, nameResolver), expression.Format, expression.Alignment, theme ?? TemplateTheme.None),
+                    ExpressionCompiler.Compile(expression.Expression, nameResolver), expression.Format, expression.Alignment, theme),
                 TemplateBlock block => new CompiledTemplateBlock(block.Elements.Select(e => Compile(e, nameResolver, theme)).ToArray()),
                 Conditional conditional => new CompiledConditional(
                     ExpressionCompiler.Compile(conditional.Condition, nameResolver),

--- a/src/Serilog.Expressions/Templates/ExpressionTemplate.cs
+++ b/src/Serilog.Expressions/Templates/ExpressionTemplate.cs
@@ -83,8 +83,7 @@ namespace Serilog.Templates
             result = new ExpressionTemplate(
                 TemplateCompiler.Compile(
                     planned,
-                    formatProvider,
-                    DefaultFunctionNameResolver.Build(nameResolver),
+                    formatProvider, DefaultFunctionNameResolver.Build(nameResolver),
                     theme ?? TemplateTheme.None));
             
             return true;
@@ -120,9 +119,7 @@ namespace Serilog.Templates
             
             _compiled = TemplateCompiler.Compile(
                 planned,
-                formatProvider,
-                DefaultFunctionNameResolver.Build(nameResolver),
-                theme ?? TemplateTheme.None);
+                formatProvider, DefaultFunctionNameResolver.Build(nameResolver), theme ?? TemplateTheme.None);
         }
 
         /// <inheritdoc />

--- a/src/Serilog.Expressions/Templates/ExpressionTemplate.cs
+++ b/src/Serilog.Expressions/Templates/ExpressionTemplate.cs
@@ -17,7 +17,6 @@ namespace Serilog.Templates
     /// </summary>
     public class ExpressionTemplate : ITextFormatter
     {
-        readonly IFormatProvider? _formatProvider;
         readonly CompiledTemplate _compiled;
         
         /// <summary>
@@ -70,17 +69,16 @@ namespace Serilog.Templates
             result = new ExpressionTemplate(
                 TemplateCompiler.Compile(
                     planned,
+                    formatProvider,
                     DefaultFunctionNameResolver.Build(nameResolver),
-                    theme ?? TemplateTheme.None),
-                formatProvider);
+                    theme ?? TemplateTheme.None));
             
             return true;
         }
         
-        ExpressionTemplate(CompiledTemplate compiled, IFormatProvider? formatProvider)
+        ExpressionTemplate(CompiledTemplate compiled)
         {
             _compiled = compiled;
-            _formatProvider = formatProvider;
         }
 
         /// <summary>
@@ -108,16 +106,15 @@ namespace Serilog.Templates
             
             _compiled = TemplateCompiler.Compile(
                 planned,
+                formatProvider,
                 DefaultFunctionNameResolver.Build(nameResolver),
                 theme ?? TemplateTheme.None);
-            
-            _formatProvider = formatProvider;
         }
 
         /// <inheritdoc />
         public void Format(LogEvent logEvent, TextWriter output)
         {
-            _compiled.Evaluate(new EvaluationContext(logEvent), output, _formatProvider);
+            _compiled.Evaluate(new EvaluationContext(logEvent), output);
         }
     }
 }

--- a/src/Serilog.Expressions/Templates/ExpressionTemplate.cs
+++ b/src/Serilog.Expressions/Templates/ExpressionTemplate.cs
@@ -71,7 +71,7 @@ namespace Serilog.Templates
                 TemplateCompiler.Compile(
                     planned,
                     DefaultFunctionNameResolver.Build(nameResolver),
-                    theme ?? TemplateTheme.None),
+                    theme),
                 formatProvider);
             
             return true;
@@ -109,7 +109,7 @@ namespace Serilog.Templates
             _compiled = TemplateCompiler.Compile(
                 planned,
                 DefaultFunctionNameResolver.Build(nameResolver),
-                theme ?? TemplateTheme.None);
+                theme);
             
             _formatProvider = formatProvider;
         }

--- a/src/Serilog.Expressions/Templates/ExpressionTemplate.cs
+++ b/src/Serilog.Expressions/Templates/ExpressionTemplate.cs
@@ -1,3 +1,17 @@
+// Copyright © Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;

--- a/src/Serilog.Expressions/Templates/ExpressionTemplate.cs
+++ b/src/Serilog.Expressions/Templates/ExpressionTemplate.cs
@@ -71,7 +71,7 @@ namespace Serilog.Templates
                 TemplateCompiler.Compile(
                     planned,
                     DefaultFunctionNameResolver.Build(nameResolver),
-                    theme),
+                    theme ?? TemplateTheme.None),
                 formatProvider);
             
             return true;
@@ -109,7 +109,7 @@ namespace Serilog.Templates
             _compiled = TemplateCompiler.Compile(
                 planned,
                 DefaultFunctionNameResolver.Build(nameResolver),
-                theme);
+                theme ?? TemplateTheme.None);
             
             _formatProvider = formatProvider;
         }

--- a/src/Serilog.Expressions/Templates/Parsing/TemplateParser.cs
+++ b/src/Serilog.Expressions/Templates/Parsing/TemplateParser.cs
@@ -1,4 +1,18 @@
-﻿using System;
+﻿// Copyright © Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 using System.Diagnostics.CodeAnalysis;
 using Serilog.Templates.Ast;
 

--- a/src/Serilog.Expressions/Templates/Parsing/TemplateParser.cs
+++ b/src/Serilog.Expressions/Templates/Parsing/TemplateParser.cs
@@ -6,8 +6,8 @@ namespace Serilog.Templates.Parsing
 {
     class TemplateParser
     {
-        readonly TemplateTokenizer _tokenizer = new TemplateTokenizer();
-        readonly TemplateTokenParsers _templateTokenParsers = new TemplateTokenParsers();
+        readonly TemplateTokenizer _tokenizer = new();
+        readonly TemplateTokenParsers _templateTokenParsers = new();
         
         public bool TryParse(
             string template,

--- a/src/Serilog.Expressions/Templates/Parsing/TemplateTokenParsers.cs
+++ b/src/Serilog.Expressions/Templates/Parsing/TemplateTokenParsers.cs
@@ -1,4 +1,18 @@
-﻿using Serilog.Expressions.Ast;
+﻿// Copyright © Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Serilog.Expressions.Ast;
 using Serilog.Expressions.Parsing;
 using Serilog.Parsing;
 using Serilog.ParserConstruction;

--- a/src/Serilog.Expressions/Templates/Parsing/TemplateTokenParsers.cs
+++ b/src/Serilog.Expressions/Templates/Parsing/TemplateTokenParsers.cs
@@ -33,7 +33,7 @@ namespace Serilog.Templates.Parsing
             var hole =
                 from _ in Token.EqualTo(LBrace)
                 from expr in ExpressionTokenParsers.Expr
-                from align in alignment.OptionalOrDefault()
+                from align in alignment.Select(a => (Alignment?)a).OptionalOrDefault()
                 from fmt in format.OptionalOrDefault()
                 from __ in Token.EqualTo(RBrace)
                 select (Template) new FormattedExpression(expr, fmt, align);
@@ -79,7 +79,7 @@ namespace Serilog.Templates.Parsing
             var eachDirective =
                 Token.EqualTo(LBraceHash)
                     .IgnoreThen(Token.EqualTo(Each)).Try()
-                    .IgnoreThen(Token.EqualTo(ExpressionToken.Identifier)
+                    .IgnoreThen(Token.EqualTo(Identifier)
                         .Select(i => i.ToStringValue())
                         .AtLeastOnceDelimitedBy(Token.EqualTo(Comma)))
                     .Then(bindings => Token.EqualTo(In).Value(bindings))

--- a/src/Serilog.Expressions/Templates/Parsing/TemplateTokenizer.cs
+++ b/src/Serilog.Expressions/Templates/Parsing/TemplateTokenizer.cs
@@ -1,4 +1,18 @@
-﻿using System.Collections.Generic;
+﻿// Copyright © Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.Generic;
 using Serilog.Expressions.Parsing;
 using Serilog.ParserConstruction;
 using Serilog.ParserConstruction.Model;

--- a/src/Serilog.Expressions/Templates/Rendering/AlignmentExtensions.cs
+++ b/src/Serilog.Expressions/Templates/Rendering/AlignmentExtensions.cs
@@ -1,4 +1,18 @@
-﻿using Serilog.Parsing;
+﻿// Copyright © Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Serilog.Parsing;
 
 namespace Serilog.Templates.Rendering
 {

--- a/src/Serilog.Expressions/Templates/Rendering/AlignmentExtensions.cs
+++ b/src/Serilog.Expressions/Templates/Rendering/AlignmentExtensions.cs
@@ -1,0 +1,12 @@
+﻿using Serilog.Parsing;
+
+namespace Serilog.Templates.Rendering
+{
+    static class AlignmentExtensions
+    {
+        public static Alignment Widen(this Alignment alignment, int amount)
+        {
+            return new(alignment.Direction, alignment.Width + amount);
+        }
+    }
+}

--- a/src/Serilog.Expressions/Templates/Themes/Style.cs
+++ b/src/Serilog.Expressions/Templates/Themes/Style.cs
@@ -1,4 +1,18 @@
-﻿using System.IO;
+﻿// Copyright © Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.IO;
 
 namespace Serilog.Templates.Themes
 {

--- a/src/Serilog.Expressions/Templates/Themes/Style.cs
+++ b/src/Serilog.Expressions/Templates/Themes/Style.cs
@@ -1,0 +1,28 @@
+﻿using System.IO;
+
+namespace Serilog.Templates.Themes
+{
+    readonly struct Style
+    {
+        readonly string? _ansiStyle;
+
+        public Style(string ansiStyle)
+        {
+            _ansiStyle = ansiStyle;
+        }
+        
+        internal StyleReset Set(TextWriter output, ref int invisibleCharacterCount)
+        {
+            if (_ansiStyle != null)
+            {
+                output.Write(_ansiStyle);
+                invisibleCharacterCount += _ansiStyle.Length;
+                invisibleCharacterCount += StyleReset.ResetCharCount;
+
+                return new StyleReset(output);
+            }
+            
+            return default;
+        }
+    }
+}

--- a/src/Serilog.Expressions/Templates/Themes/Style.cs
+++ b/src/Serilog.Expressions/Templates/Themes/Style.cs
@@ -38,5 +38,10 @@ namespace Serilog.Templates.Themes
             
             return default;
         }
+
+        public string? GetAnsiStyle()
+        {
+            return _ansiStyle;
+        }
     }
 }

--- a/src/Serilog.Expressions/Templates/Themes/StyleReset.cs
+++ b/src/Serilog.Expressions/Templates/Themes/StyleReset.cs
@@ -1,4 +1,18 @@
-﻿using System;
+﻿// Copyright © Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 using System.IO;
 
 namespace Serilog.Templates.Themes

--- a/src/Serilog.Expressions/Templates/Themes/StyleReset.cs
+++ b/src/Serilog.Expressions/Templates/Themes/StyleReset.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.IO;
+
+namespace Serilog.Templates.Themes
+{
+    readonly struct StyleReset : IDisposable
+    {
+        const string AnsiStyleResetSequence = "\x1b[0m";
+        public const int ResetCharCount = 4;
+        
+        readonly TextWriter? _output;
+        
+        public StyleReset(TextWriter output)
+        {
+            _output = output;
+        }
+
+        public void Dispose()
+        {
+            _output?.Write(AnsiStyleResetSequence);
+        }
+    }
+}

--- a/src/Serilog.Expressions/Templates/Themes/TemplateTheme.cs
+++ b/src/Serilog.Expressions/Templates/Themes/TemplateTheme.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Serilog.Templates.Themes
+{
+    /// <summary>
+    /// A template theme using the ANSI terminal escape sequences.
+    /// </summary>
+    public class TemplateTheme
+    {
+        /// <summary>
+        /// A 256-color theme along the lines of Visual Studio Code.
+        /// </summary>
+        public static TemplateTheme Code { get; } = TemplateThemes.Code;
+
+        /// <summary>
+        /// A theme using only gray, black and white.
+        /// </summary>
+        public static TemplateTheme Grayscale { get; } = TemplateThemes.Grayscale;
+
+        /// <summary>
+        /// A theme in the style of the original <i>Serilog.Sinks.Literate</i>.
+        /// </summary>
+        public static TemplateTheme Literate { get; } = TemplateThemes.Literate;
+
+        internal static TemplateTheme None { get; } = new TemplateTheme(new Dictionary<TemplateThemeStyle, string>());
+
+        readonly IReadOnlyDictionary<TemplateThemeStyle, Style> _styles;
+
+        /// <summary>
+        /// Construct a theme given a set of styles.
+        /// </summary>
+        /// <param name="styles">Styles to apply within the theme.</param>
+        /// <exception cref="ArgumentNullException">When <paramref name="styles"/> is <code>null</code></exception>
+        public TemplateTheme(IReadOnlyDictionary<TemplateThemeStyle, string> styles)
+        {
+            if (styles is null) throw new ArgumentNullException(nameof(styles));
+            _styles = styles.ToDictionary(kv => kv.Key, kv => new Style(kv.Value));
+        }
+
+        internal Style GetStyle(TemplateThemeStyle templateThemeStyle)
+        {
+            _styles.TryGetValue(templateThemeStyle, out var style);
+            return style;
+        }
+    }
+}

--- a/src/Serilog.Expressions/Templates/Themes/TemplateTheme.cs
+++ b/src/Serilog.Expressions/Templates/Themes/TemplateTheme.cs
@@ -40,17 +40,34 @@ namespace Serilog.Templates.Themes
 
         internal static TemplateTheme None { get; } = new TemplateTheme(new Dictionary<TemplateThemeStyle, string>());
 
-        readonly IReadOnlyDictionary<TemplateThemeStyle, Style> _styles;
+        readonly Dictionary<TemplateThemeStyle, Style> _styles;
 
         /// <summary>
         /// Construct a theme given a set of styles.
         /// </summary>
-        /// <param name="styles">Styles to apply within the theme.</param>
-        /// <exception cref="ArgumentNullException">When <paramref name="styles"/> is <code>null</code></exception>
-        public TemplateTheme(IReadOnlyDictionary<TemplateThemeStyle, string> styles)
+        /// <param name="ansiStyles">Styles to apply within the theme. The dictionary maps style names to ANSI
+        /// sequences implementing the styles.</param>
+        /// <exception cref="ArgumentNullException">When <paramref name="ansiStyles"/> is <code>null</code></exception>
+        public TemplateTheme(IReadOnlyDictionary<TemplateThemeStyle, string> ansiStyles)
         {
-            if (styles is null) throw new ArgumentNullException(nameof(styles));
-            _styles = styles.ToDictionary(kv => kv.Key, kv => new Style(kv.Value));
+            if (ansiStyles is null) throw new ArgumentNullException(nameof(ansiStyles));
+            _styles = ansiStyles.ToDictionary(kv => kv.Key, kv => new Style(kv.Value));
+        }
+
+        /// <summary>
+        /// Construct a theme given a set of styles.
+        /// </summary>
+        /// <param name="baseTheme">A base template theme, which will supply styles not overridden in <paramref name="ansiStyles"/>.</param>
+        /// <param name="ansiStyles">Styles to apply within the theme. The dictionary maps style names to ANSI
+        /// sequences implementing the styles.</param>
+        /// <exception cref="ArgumentNullException">When <paramref name="ansiStyles"/> is <code>null</code></exception>
+        public TemplateTheme(TemplateTheme baseTheme, IReadOnlyDictionary<TemplateThemeStyle, string> ansiStyles)
+        {
+            if (baseTheme == null) throw new ArgumentNullException(nameof(baseTheme));
+            if (ansiStyles is null) throw new ArgumentNullException(nameof(ansiStyles));
+            _styles = new Dictionary<TemplateThemeStyle, Style>(baseTheme._styles);
+            foreach (var kv in ansiStyles)
+                _styles[kv.Key] = new Style(kv.Value);
         }
 
         internal Style GetStyle(TemplateThemeStyle templateThemeStyle)

--- a/src/Serilog.Expressions/Templates/Themes/TemplateTheme.cs
+++ b/src/Serilog.Expressions/Templates/Themes/TemplateTheme.cs
@@ -1,4 +1,18 @@
-﻿using System;
+﻿// Copyright © Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 

--- a/src/Serilog.Expressions/Templates/Themes/TemplateThemeStyle.cs
+++ b/src/Serilog.Expressions/Templates/Themes/TemplateThemeStyle.cs
@@ -1,4 +1,18 @@
-﻿namespace Serilog.Templates.Themes
+﻿// Copyright © Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Serilog.Templates.Themes
 {
     /// <summary>
     /// Elements styled by a template theme.

--- a/src/Serilog.Expressions/Templates/Themes/TemplateThemeStyle.cs
+++ b/src/Serilog.Expressions/Templates/Themes/TemplateThemeStyle.cs
@@ -1,0 +1,90 @@
+﻿namespace Serilog.Templates.Themes
+{
+    /// <summary>
+    /// Elements styled by a template theme.
+    /// </summary>
+    public enum TemplateThemeStyle
+    {
+        /// <summary>
+        /// Prominent text, generally content within an event's message.
+        /// </summary>
+        Text,
+
+        /// <summary>
+        /// Boilerplate text, for example items specified in an output template.
+        /// </summary>
+        SecondaryText,
+
+        /// <summary>
+        /// De-emphasized text, for example literal text in output templates and
+        /// punctuation used when writing structured data.
+        /// </summary>
+        TertiaryText,
+
+        /// <summary>
+        /// Output demonstrating some kind of configuration issue, e.g. an invalid
+        /// message template token.
+        /// </summary>
+        Invalid,
+
+        /// <summary>
+        /// The built-in <see langword="null"/> value.
+        /// </summary>
+        Null,
+
+        /// <summary>
+        /// Property and type names.
+        /// </summary>
+        Name,
+
+        /// <summary>
+        /// Strings.
+        /// </summary>
+        String,
+
+        /// <summary>
+        /// Numbers.
+        /// </summary>
+        Number,
+
+        /// <summary>
+        /// <see cref="bool"/> values.
+        /// </summary>
+        Boolean,
+
+        /// <summary>
+        /// All other scalar values, e.g. <see cref="System.Guid"/> instances.
+        /// </summary>
+        Scalar,
+
+        /// <summary>
+        /// Level indicator.
+        /// </summary>
+        LevelVerbose,
+
+        /// <summary>
+        /// Level indicator.
+        /// </summary>
+        LevelDebug,
+
+        /// <summary>
+        /// Level indicator.
+        /// </summary>
+        LevelInformation,
+
+        /// <summary>
+        /// Level indicator.
+        /// </summary>
+        LevelWarning,
+
+        /// <summary>
+        /// Level indicator.
+        /// </summary>
+        LevelError,
+
+        /// <summary>
+        /// Level indicator.
+        /// </summary>
+        LevelFatal,
+    }
+}

--- a/src/Serilog.Expressions/Templates/Themes/TemplateThemes.cs
+++ b/src/Serilog.Expressions/Templates/Themes/TemplateThemes.cs
@@ -1,0 +1,70 @@
+﻿using System.Collections.Generic;
+
+namespace Serilog.Templates.Themes
+{
+    static class TemplateThemes
+    {
+        public static TemplateTheme Literate { get; } = new(
+            new Dictionary<TemplateThemeStyle, string>
+            {
+                [TemplateThemeStyle.Text] = "\x1b[38;5;0015m",
+                [TemplateThemeStyle.SecondaryText] = "\x1b[38;5;0007m",
+                [TemplateThemeStyle.TertiaryText] = "\x1b[38;5;0008m",
+                [TemplateThemeStyle.Invalid] = "\x1b[38;5;0011m",
+                [TemplateThemeStyle.Null] = "\x1b[38;5;0027m",
+                [TemplateThemeStyle.Name] = "\x1b[38;5;0007m",
+                [TemplateThemeStyle.String] = "\x1b[38;5;0045m",
+                [TemplateThemeStyle.Number] = "\x1b[38;5;0200m",
+                [TemplateThemeStyle.Boolean] = "\x1b[38;5;0027m",
+                [TemplateThemeStyle.Scalar] = "\x1b[38;5;0085m",
+                [TemplateThemeStyle.LevelVerbose] = "\x1b[38;5;0007m",
+                [TemplateThemeStyle.LevelDebug] = "\x1b[38;5;0007m",
+                [TemplateThemeStyle.LevelInformation] = "\x1b[38;5;0015m",
+                [TemplateThemeStyle.LevelWarning] = "\x1b[38;5;0011m",
+                [TemplateThemeStyle.LevelError] = "\x1b[38;5;0015m\x1b[48;5;0196m",
+                [TemplateThemeStyle.LevelFatal] = "\x1b[38;5;0015m\x1b[48;5;0196m",
+            });
+
+        public static TemplateTheme Grayscale { get; } = new(
+            new Dictionary<TemplateThemeStyle, string>
+            {
+                [TemplateThemeStyle.Text] = "\x1b[37;1m",
+                [TemplateThemeStyle.SecondaryText] = "\x1b[37m",
+                [TemplateThemeStyle.TertiaryText] = "\x1b[30;1m",
+                [TemplateThemeStyle.Invalid] = "\x1b[37;1m\x1b[47m",
+                [TemplateThemeStyle.Null] = "\x1b[1m\x1b[37;1m",
+                [TemplateThemeStyle.Name] = "\x1b[37m",
+                [TemplateThemeStyle.String] = "\x1b[1m\x1b[37;1m",
+                [TemplateThemeStyle.Number] = "\x1b[1m\x1b[37;1m",
+                [TemplateThemeStyle.Boolean] = "\x1b[1m\x1b[37;1m",
+                [TemplateThemeStyle.Scalar] = "\x1b[1m\x1b[37;1m",
+                [TemplateThemeStyle.LevelVerbose] = "\x1b[30;1m",
+                [TemplateThemeStyle.LevelDebug] = "\x1b[30;1m",
+                [TemplateThemeStyle.LevelInformation] = "\x1b[37;1m",
+                [TemplateThemeStyle.LevelWarning] = "\x1b[37;1m\x1b[47m",
+                [TemplateThemeStyle.LevelError] = "\x1b[30m\x1b[47m",
+                [TemplateThemeStyle.LevelFatal] = "\x1b[30m\x1b[47m",
+            });
+
+        public static TemplateTheme Code { get; } = new(
+            new Dictionary<TemplateThemeStyle, string>
+            {
+                [TemplateThemeStyle.Text] = "\x1b[38;5;0253m",
+                [TemplateThemeStyle.SecondaryText] = "\x1b[38;5;0246m",
+                [TemplateThemeStyle.TertiaryText] = "\x1b[38;5;0242m",
+                [TemplateThemeStyle.Invalid] = "\x1b[33;1m",
+                [TemplateThemeStyle.Null] = "\x1b[38;5;0038m",
+                [TemplateThemeStyle.Name] = "\x1b[38;5;0081m",
+                [TemplateThemeStyle.String] = "\x1b[38;5;0216m",
+                [TemplateThemeStyle.Number] = "\x1b[38;5;151m",
+                [TemplateThemeStyle.Boolean] = "\x1b[38;5;0038m",
+                [TemplateThemeStyle.Scalar] = "\x1b[38;5;0079m",
+                [TemplateThemeStyle.LevelVerbose] = "\x1b[37m",
+                [TemplateThemeStyle.LevelDebug] = "\x1b[37m",
+                [TemplateThemeStyle.LevelInformation] = "\x1b[37;1m",
+                [TemplateThemeStyle.LevelWarning] = "\x1b[38;5;0229m",
+                [TemplateThemeStyle.LevelError] = "\x1b[38;5;0197m\x1b[48;5;0238m",
+                [TemplateThemeStyle.LevelFatal] = "\x1b[38;5;0197m\x1b[48;5;0238m",
+            });
+    }
+}

--- a/src/Serilog.Expressions/Templates/Themes/TemplateThemes.cs
+++ b/src/Serilog.Expressions/Templates/Themes/TemplateThemes.cs
@@ -1,4 +1,18 @@
-﻿using System.Collections.Generic;
+﻿// Copyright © Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.Generic;
 
 namespace Serilog.Templates.Themes
 {

--- a/src/Serilog.Expressions/Templates/Themes/ThemedJsonValueFormatter.cs
+++ b/src/Serilog.Expressions/Templates/Themes/ThemedJsonValueFormatter.cs
@@ -1,0 +1,240 @@
+﻿using System;
+using System.Globalization;
+using System.IO;
+using Serilog.Data;
+using Serilog.Events;
+using Serilog.Formatting.Json;
+
+// ReSharper disable ForCanBeConvertedToForeach
+
+namespace Serilog.Templates.Themes
+{
+    class ThemedJsonValueFormatter : LogEventPropertyValueVisitor<TextWriter, int>
+    {
+        const string TypeTagPropertyName = "$type";
+        
+        readonly Style _null, _bool, _num, _string, _scalar, _tertiary, _name;
+
+        public ThemedJsonValueFormatter(TemplateTheme theme)
+        {
+            _null = theme.GetStyle(TemplateThemeStyle.Null);
+            _bool = theme.GetStyle(TemplateThemeStyle.Boolean);
+            _num = theme.GetStyle(TemplateThemeStyle.Number);
+            _string = theme.GetStyle(TemplateThemeStyle.String);
+            _scalar = theme.GetStyle(TemplateThemeStyle.Scalar);
+            _tertiary = theme.GetStyle(TemplateThemeStyle.TertiaryText);
+            _name = theme.GetStyle(TemplateThemeStyle.Name);
+        }
+
+        public int Format(LogEventPropertyValue value, TextWriter output)
+        {
+            return Visit(output, value);
+        }
+        
+        protected override int VisitScalarValue(TextWriter state, ScalarValue scalar)
+        {
+            return FormatLiteralValue(scalar, state);
+        }
+
+        protected override int VisitSequenceValue(TextWriter state, SequenceValue sequence)
+        {
+            var count = 0;
+            
+            using (_tertiary.Set(state, ref count))
+                state.Write('[');
+
+            var delim = string.Empty;
+            for (var index = 0; index < sequence.Elements.Count; ++index)
+            {
+                if (delim.Length != 0)
+                {
+                    using (_tertiary.Set(state, ref count))
+                        state.Write(delim);
+                }
+
+                delim = ",";
+                count += Visit(state, sequence.Elements[index]);
+            }
+
+            using (_tertiary.Set(state, ref count))
+                state.Write(']');
+
+            return count;
+
+        }
+
+        protected override int VisitStructureValue(TextWriter state, StructureValue structure)
+        {
+            var count = 0;
+
+            using (_tertiary.Set(state, ref count))
+                state.Write('{');
+
+            var delim = string.Empty;
+            for (var index = 0; index < structure.Properties.Count; ++index)
+            {
+                if (delim.Length != 0)
+                {
+                    using (_tertiary.Set(state, ref count))
+                        state.Write(delim);
+                }
+
+                delim = ",";
+
+                var property = structure.Properties[index];
+
+                using (_name.Set(state, ref count))
+                    JsonValueFormatter.WriteQuotedJsonString(property.Name, state);
+
+                using (_tertiary.Set(state, ref count))
+                    state.Write(":");
+
+                count += Visit(state, property.Value);
+            }
+
+            if (structure.TypeTag != null)
+            {
+                using (_tertiary.Set(state, ref count))
+                    state.Write(delim);
+
+                using (_name.Set(state, ref count))
+                    JsonValueFormatter.WriteQuotedJsonString(TypeTagPropertyName, state);
+
+                using (_tertiary.Set(state, ref count))
+                    state.Write(":");
+
+                using (_string.Set(state, ref count))
+                    JsonValueFormatter.WriteQuotedJsonString(structure.TypeTag, state);
+            }
+
+            using (_tertiary.Set(state, ref count))
+                state.Write('}');
+
+            return count;
+        }
+
+        protected override int VisitDictionaryValue(TextWriter state, DictionaryValue dictionary)
+        {
+            var count = 0;
+
+            using (_tertiary.Set(state, ref count))
+                state.Write('{');
+
+            var delim = string.Empty;
+            foreach (var element in dictionary.Elements)
+            {
+                if (delim.Length != 0)
+                {
+                    using (_tertiary.Set(state, ref count))
+                        state.Write(delim);
+                }
+
+                delim = ",";
+
+                var style = element.Key.Value == null
+                    ? _null
+                    : element.Key.Value is string
+                        ? _string
+                        : _scalar;
+
+                using (style.Set(state, ref count))
+                    JsonValueFormatter.WriteQuotedJsonString((element.Key.Value ?? "null").ToString(), state);
+
+                using (_tertiary.Set(state, ref count))
+                    state.Write(":");
+
+                count += Visit(state, element.Value);
+            }
+
+            using (_tertiary.Set(state, ref count))
+                state.Write('}');
+
+            return count;
+        }
+        
+        int FormatLiteralValue(ScalarValue scalar, TextWriter output)
+        {
+            var value = scalar.Value;
+            var count = 0;
+
+            if (value == null)
+            {
+                using (_null.Set(output, ref count))
+                    output.Write("null");
+                return count;
+            }
+
+            if (value is string str)
+            {
+                using (_string.Set(output, ref count))
+                    JsonValueFormatter.WriteQuotedJsonString(str, output);
+                return count;
+            }
+
+            if (value is ValueType)
+            {
+                if (value is int || value is uint || value is long || value is ulong || value is decimal || value is byte || value is sbyte || value is short || value is ushort)
+                {
+                    using (_num.Set(output, ref count))
+                        output.Write(((IFormattable)value).ToString(null, CultureInfo.InvariantCulture));
+                    return count;
+                }
+
+                if (value is double d)
+                {
+                    using (_num.Set(output, ref count))
+                    {
+                        if (double.IsNaN(d) || double.IsInfinity(d))
+                            JsonValueFormatter.WriteQuotedJsonString(d.ToString(CultureInfo.InvariantCulture), output);
+                        else
+                            output.Write(d.ToString("R", CultureInfo.InvariantCulture));
+                    }
+                    return count;
+                }
+
+                if (value is float f)
+                {
+                    using (_num.Set(output, ref count))
+                    {
+                        if (double.IsNaN(f) || double.IsInfinity(f))
+                            JsonValueFormatter.WriteQuotedJsonString(f.ToString(CultureInfo.InvariantCulture), output);
+                        else
+                            output.Write(f.ToString("R", CultureInfo.InvariantCulture));
+                    }
+                    return count;
+                }
+
+                if (value is bool b)
+                {
+                    using (_bool.Set(output, ref count))
+                        output.Write(b ? "true" : "false");
+
+                    return count;
+                }
+
+                if (value is char ch)
+                {
+                    using (_scalar.Set(output, ref count))
+                        JsonValueFormatter.WriteQuotedJsonString(ch.ToString(), output);
+                    return count;
+                }
+
+                if (value is DateTime or DateTimeOffset)
+                {
+                    using (_scalar.Set(output, ref count))
+                    {
+                        output.Write('"');
+                        output.Write(((IFormattable)value).ToString("O", CultureInfo.InvariantCulture));
+                        output.Write('"');
+                    }
+                    return count;
+                }
+            }
+
+            using (_scalar.Set(output, ref count))
+                JsonValueFormatter.WriteQuotedJsonString(value.ToString(), output);
+
+            return count;
+        }
+    }
+}

--- a/src/Serilog.Expressions/Templates/Themes/ThemedJsonValueFormatter.cs
+++ b/src/Serilog.Expressions/Templates/Themes/ThemedJsonValueFormatter.cs
@@ -1,4 +1,18 @@
-﻿using System;
+﻿// Copyright © Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 using System.Globalization;
 using System.IO;
 using Serilog.Data;

--- a/src/Serilog.Expressions/Templates/Themes/ThemedJsonValueFormatter.cs
+++ b/src/Serilog.Expressions/Templates/Themes/ThemedJsonValueFormatter.cs
@@ -173,7 +173,7 @@ namespace Serilog.Templates.Themes
 
             if (value is ValueType)
             {
-                if (value is int || value is uint || value is long || value is ulong || value is decimal || value is byte || value is sbyte || value is short || value is ushort)
+                if (value is int or uint or long or ulong or decimal or byte or sbyte or short or ushort)
                 {
                     using (_num.Set(output, ref count))
                         output.Write(((IFormattable)value).ToString(null, CultureInfo.InvariantCulture));

--- a/test/Serilog.Expressions.Tests/Cases/expression-evaluation-cases.asv
+++ b/test/Serilog.Expressions.Tests/Cases/expression-evaluation-cases.asv
@@ -231,6 +231,9 @@ tostring('test', 42)                 ⇶ undefined()
 tostring(16, undefined())            ⇶ '16'
 tostring(16, null)                   ⇶ '16'
 
+// Tests are in fr-FR
+tostring(16.3)                       ⇶ '16,3'
+
 // TypeOf
 typeof(undefined())                  ⇶ 'undefined'
 typeof('test')                       ⇶ 'System.String'

--- a/test/Serilog.Expressions.Tests/Cases/template-evaluation-cases.asv
+++ b/test/Serilog.Expressions.Tests/Cases/template-evaluation-cases.asv
@@ -26,3 +26,4 @@ A{#if false}B{#else if true}C{#end}                  ⇶ AC
 {#each a, b in {x: 1, y: 2}}{a}.{b}{#end}            ⇶ x.1y.2
 {#if true}A{#each a in [1]}B{a}{#end}C{#end}D        ⇶ AB1CD
 {#each a in []}{a}!{#else}none{#end}                 ⇶ none
+Culture-specific {42.34}                             ⇶ Culture-specific 42,34

--- a/test/Serilog.Expressions.Tests/ExpressionEvaluationTests.cs
+++ b/test/Serilog.Expressions.Tests/ExpressionEvaluationTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using Serilog.Events;
@@ -26,8 +27,9 @@ namespace Serilog.Expressions.Tests
                     new LogEventProperty("Id", new ScalarValue(42)),
                     new LogEventProperty("Name", new ScalarValue("nblumhardt")), 
                 })));
-            
-            var actual = SerilogExpression.Compile(expr)(evt);
+
+            var frFr = CultureInfo.GetCultureInfoByIetfLanguageTag("fr-FR");
+            var actual = SerilogExpression.Compile(expr, formatProvider: frFr)(evt);
             var expected = SerilogExpression.Compile(result)(evt);
 
             if (expected is null)

--- a/test/Serilog.Expressions.Tests/Expressions/NameResolverTests.cs
+++ b/test/Serilog.Expressions.Tests/Expressions/NameResolverTests.cs
@@ -20,7 +20,7 @@ namespace Serilog.Expressions.Tests.Expressions
         {
             var expr = SerilogExpression.Compile(
                 "magic(10) + 3 = 55",
-                new StaticMemberNameResolver(typeof(NameResolverTests)));
+                nameResolver: new StaticMemberNameResolver(typeof(NameResolverTests)));
             Assert.True(Coerce.IsTrue(expr(Some.InformationEvent())));
         }
     }

--- a/test/Serilog.Expressions.Tests/TemplateEvaluationTests.cs
+++ b/test/Serilog.Expressions.Tests/TemplateEvaluationTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using Serilog.Expressions.Tests.Support;
 using Serilog.Templates;
@@ -16,7 +17,8 @@ namespace Serilog.Expressions.Tests
         public void TemplatesAreCorrectlyEvaluated(string template, string expected)
         {
             var evt = Some.InformationEvent("Hello, {Name}!", "nblumhardt");
-            var compiled = new ExpressionTemplate(template);
+            var frFr = CultureInfo.GetCultureInfoByIetfLanguageTag("fr-FR");
+            var compiled = new ExpressionTemplate(template, formatProvider: frFr);
             var output = new StringWriter();
             compiled.Format(evt, output);
             var actual = output.ToString();

--- a/test/Serilog.Expressions.Tests/TemplateParserTests.cs
+++ b/test/Serilog.Expressions.Tests/TemplateParserTests.cs
@@ -17,7 +17,7 @@ namespace Serilog.Expressions.Tests
         [InlineData("Empty {Align,} digits", "Syntax error (line 1, column 14): unexpected `}`, expected alignment and width.")]
         public void ErrorsAreReported(string input, string error)
         {
-            Assert.False(ExpressionTemplate.TryParse(input, null, null, out _, out var actual));
+            Assert.False(ExpressionTemplate.TryParse(input, null, null, null, out _, out var actual));
             Assert.Equal(error, actual);
         }
     }

--- a/test/Serilog.Expressions.Tests/TemplateParserTests.cs
+++ b/test/Serilog.Expressions.Tests/TemplateParserTests.cs
@@ -1,4 +1,6 @@
 ﻿using Serilog.Templates;
+using Serilog.Templates.Ast;
+using Serilog.Templates.Parsing;
 using Xunit;
 
 namespace Serilog.Expressions.Tests
@@ -19,6 +21,15 @@ namespace Serilog.Expressions.Tests
         {
             Assert.False(ExpressionTemplate.TryParse(input, null, null, null, out _, out var actual));
             Assert.Equal(error, actual);
+        }
+
+        [Fact]
+        public void DefaultAlignmentIsNull()
+        {
+            var parser = new TemplateParser();
+            Assert.True(parser.TryParse("{x}", out var template, out _));
+            var avt = Assert.IsType<FormattedExpression>(template);
+            Assert.Null(avt.Alignment);
         }
     }
 }


### PR DESCRIPTION
Fixes #8, fixes #19.

Theming is implemented by the `TemplateTheme` class; built-in themes are `TemplateTheme.Code`, `TemplateTheme.Grayscale`, and `TemplateTheme.Literate`, which were lifted directly from _Serilog.Sinks.Console_.

Themes can be user-specified, and can inherit from a "base" theme:

```csharp
var melon = new TemplateTheme(TemplateTheme.Literate, new Dictionary<TemplateThemeStyle, string>
{
    // `Information` is dark green in MEL.
    [TemplateThemeStyle.LevelInformation] = "\x1b[38;5;34m",
    [TemplateThemeStyle.String] = "\x1b[38;5;159m",
    [TemplateThemeStyle.Number] = "\x1b[38;5;159m"
});

using var log = new LoggerConfiguration()
    .WriteTo.Console(new ExpressionTemplate(
        "{@l:w4}: {SourceContext}\n" +
        "{#if Scope is not null}" +
        "      {#each s in Scope}=> {s}{#delimit} {#end}\n" +
        "{#end}" +
        "      {@m}\n" +
        "{@x}",
        theme: melon))
    .CreateLogger();
```

Produces:

![image](https://user-images.githubusercontent.com/342712/120244468-9b907b00-c2ad-11eb-9690-bd9c30d72605.png)

(LOL 😁)

Only ANSI escape sequence-based theming is supported (so on Windows, only recent versions of the console will support them, along with Windows Terminal).

Themed message template rendering touched on support for `IFormatProvider`, so I've rolled in those changes, too.

There's minor API breakage, with optional or nullable `IFormatProvider` arguments added to the various `SerilogExpression` factory methods, and optional/nullable `TemplateTheme` arguments added to the `ExpressionTemplate` constructors/factory methods.

Fun twist - since the same templating implementation is used for text and JSON output, you can also do this:

![image](https://user-images.githubusercontent.com/342712/120244938-f5de0b80-c2ae-11eb-884c-502e43965318.png)

Perf impact shouldn't be huge, and since more work is brought back to template "compile" time (there are no runtime dictionary lookups), I'm expecting that theming will be slightly faster here than in _Serilog.Sinks.Console_, but that's for another day.

Tests are also a bit light, but the code paths covered by themed and un-themed output are identical apart from the behavior implemented in the (tiny) `Style` and `StyleReset` structs, so I think I can get away with it 😉
