### PR TITLE
Improve parameter binding and allow user-defined parameter types

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ calling a function will be undefined if:
 | `LastIndexOf(s, t)` | Returns the last index of substring `t` in string `s`, or -1 if the substring does not appear. |
 | `Length(x)` | Returns the length of a string or array. |
 | `Now()` | Returns `DateTimeOffset.Now`. |
+| `Rest()` | In an `ExpressionTemplate`, returns an object containing the first-class event properties not otherwise referenced in the template or the event's message. |
 | `Round(n, m)` | Round the number `n` to `m` decimal places. |
 | `StartsWith(s, t)` | Tests whether the string `s` starts with substring `t`. |
 | `Substring(s, start, [length])` | Return the substring of string `s` from `start` to the end of the string, or of `length` characters, if this argument is supplied. |

--- a/example/Sample/Program.cs
+++ b/example/Sample/Program.cs
@@ -23,10 +23,11 @@ namespace Sample
         static void TextFormattingExample1()
         {
             using var log = new LoggerConfiguration()
+                .Enrich.WithProperty("Application", "Sample")
                 .WriteTo.Console(new ExpressionTemplate(
                     "[{@t:HH:mm:ss} {@l:u3}" +
                     "{#if SourceContext is not null} ({Substring(SourceContext, LastIndexOf(SourceContext, '.') + 1)}){#end}] " +
-                    "{@m} (first item is {coalesce(Items[0], '<empty>')})\n{@x}",
+                    "{@m} (first item is {coalesce(Items[0], '<empty>')}) {rest()}\n{@x}",
                     theme: TemplateTheme.Code))
                 .CreateLogger();
 

--- a/src/Serilog.Expressions/Expressions/Compilation/OrderedNameResolver.cs
+++ b/src/Serilog.Expressions/Expressions/Compilation/OrderedNameResolver.cs
@@ -39,5 +39,17 @@ namespace Serilog.Expressions.Compilation
             implementation = null;
             return false;
         }
+
+        public override bool TryBindFunctionParameter(ParameterInfo parameter, [MaybeNullWhen(false)] out object boundValue)
+        {
+            foreach (var resolver in _orderedResolvers)
+            {
+                if (resolver.TryBindFunctionParameter(parameter, out boundValue))
+                    return true;
+            }
+
+            boundValue = null;
+            return false;
+        }
     }
 }

--- a/src/Serilog.Expressions/Expressions/Compilation/Text/LikeSyntaxTransformer.cs
+++ b/src/Serilog.Expressions/Expressions/Compilation/Text/LikeSyntaxTransformer.cs
@@ -30,21 +30,21 @@ namespace Serilog.Expressions.Compilation.Text
             return Instance.Transform(expression);
         }
 
-        protected override Expression Transform(CallExpression lx)
+        protected override Expression Transform(CallExpression call)
         {
-            if (lx.Operands.Length != 2)
-                return base.Transform(lx);
+            if (call.Operands.Length != 2)
+                return base.Transform(call);
 
-            if (Operators.SameOperator(lx.OperatorName, Operators.IntermediateOpLike))
-                return TryCompileLikeExpression(lx.IgnoreCase, lx.Operands[0], lx.Operands[1]);
+            if (Operators.SameOperator(call.OperatorName, Operators.IntermediateOpLike))
+                return TryCompileLikeExpression(call.IgnoreCase, call.Operands[0], call.Operands[1]);
             
-            if (Operators.SameOperator(lx.OperatorName, Operators.IntermediateOpNotLike))
+            if (Operators.SameOperator(call.OperatorName, Operators.IntermediateOpNotLike))
                 return new CallExpression(
                     false,
                     Operators.RuntimeOpStrictNot,
-                    TryCompileLikeExpression(lx.IgnoreCase, lx.Operands[0], lx.Operands[1]));
+                    TryCompileLikeExpression(call.IgnoreCase, call.Operands[0], call.Operands[1]));
 
-            return base.Transform(lx);
+            return base.Transform(call);
         }
 
         Expression TryCompileLikeExpression(bool ignoreCase, Expression corpus, Expression like)

--- a/src/Serilog.Expressions/Expressions/Compilation/Text/TextMatchingTransformer.cs
+++ b/src/Serilog.Expressions/Expressions/Compilation/Text/TextMatchingTransformer.cs
@@ -30,22 +30,22 @@ namespace Serilog.Expressions.Compilation.Text
             return Instance.Transform(expression);
         }
 
-        protected override Expression Transform(CallExpression lx)
+        protected override Expression Transform(CallExpression call)
         {
-            if (lx.Operands.Length != 2)
-                return base.Transform(lx);
+            if (call.Operands.Length != 2)
+                return base.Transform(call);
 
-            if (Operators.SameOperator(lx.OperatorName, Operators.OpIndexOfMatch))
-                return TryCompileIndexOfMatch(lx.IgnoreCase, lx.Operands[0], lx.Operands[1]);
+            if (Operators.SameOperator(call.OperatorName, Operators.OpIndexOfMatch))
+                return TryCompileIndexOfMatch(call.IgnoreCase, call.Operands[0], call.Operands[1]);
             
-            if (Operators.SameOperator(lx.OperatorName, Operators.OpIsMatch))
+            if (Operators.SameOperator(call.OperatorName, Operators.OpIsMatch))
                 return new CallExpression(
                     false,
                     Operators.RuntimeOpNotEqual,
-                    TryCompileIndexOfMatch(lx.IgnoreCase, lx.Operands[0], lx.Operands[1]),
+                    TryCompileIndexOfMatch(call.IgnoreCase, call.Operands[0], call.Operands[1]),
                     new ConstantExpression(new ScalarValue(-1)));
 
-            return base.Transform(lx);
+            return base.Transform(call);
         }
 
         Expression TryCompileIndexOfMatch(bool ignoreCase, Expression corpus, Expression regex)

--- a/src/Serilog.Expressions/Expressions/Compilation/Transformations/IdentityTransformer.cs
+++ b/src/Serilog.Expressions/Expressions/Compilation/Transformations/IdentityTransformer.cs
@@ -25,11 +25,11 @@ namespace Serilog.Expressions.Compilation.Transformations
             return !ReferenceEquals(expr, result);
         }
         
-        protected override Expression Transform(CallExpression lx)
+        protected override Expression Transform(CallExpression call)
         {
             var any = false;
             var operands = new List<Expression>();
-            foreach (var op in lx.Operands)
+            foreach (var op in call.Operands)
             {
                 if (TryTransform(op, out var result))
                     any = true;
@@ -37,9 +37,9 @@ namespace Serilog.Expressions.Compilation.Transformations
             }
 
             if (!any)
-                return lx;
+                return call;
             
-            return new CallExpression(lx.IgnoreCase, lx.OperatorName, operands.ToArray());
+            return new CallExpression(call.IgnoreCase, call.OperatorName, operands.ToArray());
         }
 
         protected override Expression Transform(ConstantExpression cx)

--- a/src/Serilog.Expressions/Expressions/Compilation/Transformations/SerilogExpressionTransformer.cs
+++ b/src/Serilog.Expressions/Expressions/Compilation/Transformations/SerilogExpressionTransformer.cs
@@ -41,7 +41,7 @@ namespace Serilog.Expressions.Compilation.Transformations
             };
         }
 
-        protected abstract TResult Transform(CallExpression lx);
+        protected abstract TResult Transform(CallExpression call);
         protected abstract TResult Transform(ConstantExpression cx);
         protected abstract TResult Transform(AmbientNameExpression px);
         protected abstract TResult Transform(LocalNameExpression nlx);

--- a/src/Serilog.Expressions/Expressions/Compilation/Variadics/VariadicCallRewriter.cs
+++ b/src/Serilog.Expressions/Expressions/Compilation/Variadics/VariadicCallRewriter.cs
@@ -28,38 +28,38 @@ namespace Serilog.Expressions.Compilation.Variadics
             return Instance.Transform(expression);
         }
 
-        protected override Expression Transform(CallExpression lx)
+        protected override Expression Transform(CallExpression call)
         {
-            if (Operators.SameOperator(lx.OperatorName, Operators.OpSubstring) && lx.Operands.Length == 2)
+            if (Operators.SameOperator(call.OperatorName, Operators.OpSubstring) && call.Operands.Length == 2)
             {
-                var operands = lx.Operands
+                var operands = call.Operands
                     .Select(Transform)
                     .Concat(new[] {CallUndefined()})
                     .ToArray();
-                return new CallExpression(lx.IgnoreCase, lx.OperatorName, operands);
+                return new CallExpression(call.IgnoreCase, call.OperatorName, operands);
             }
 
-            if (Operators.SameOperator(lx.OperatorName, Operators.OpCoalesce))
+            if (Operators.SameOperator(call.OperatorName, Operators.OpCoalesce))
             {
-                if (lx.Operands.Length == 0)
+                if (call.Operands.Length == 0)
                     return CallUndefined();
-                if (lx.Operands.Length == 1)
-                    return Transform(lx.Operands.Single());
-                if (lx.Operands.Length > 2)
+                if (call.Operands.Length == 1)
+                    return Transform(call.Operands.Single());
+                if (call.Operands.Length > 2)
                 {
-                    var first = Transform(lx.Operands.First());
-                    return new CallExpression(lx.IgnoreCase, lx.OperatorName, first,
-                        Transform(new CallExpression(lx.IgnoreCase, lx.OperatorName, lx.Operands.Skip(1).ToArray())));
+                    var first = Transform(call.Operands.First());
+                    return new CallExpression(call.IgnoreCase, call.OperatorName, first,
+                        Transform(new CallExpression(call.IgnoreCase, call.OperatorName, call.Operands.Skip(1).ToArray())));
                 }
             }
 
-            if (Operators.SameOperator(lx.OperatorName, Operators.OpToString) &&
-                lx.Operands.Length == 1)
+            if (Operators.SameOperator(call.OperatorName, Operators.OpToString) &&
+                call.Operands.Length == 1)
             {
-                return new CallExpression(lx.IgnoreCase, lx.OperatorName, lx.Operands[0], CallUndefined());
+                return new CallExpression(call.IgnoreCase, call.OperatorName, call.Operands[0], CallUndefined());
             }
 
-            return base.Transform(lx);
+            return base.Transform(call);
         }
 
         static CallExpression CallUndefined()

--- a/src/Serilog.Expressions/Expressions/Compilation/Wildcards/WildcardSearch.cs
+++ b/src/Serilog.Expressions/Expressions/Compilation/Wildcards/WildcardSearch.cs
@@ -76,14 +76,14 @@ namespace Serilog.Expressions.Compilation.Wildcards
             return null;
         }
 
-        protected override IndexerExpression? Transform(CallExpression lx)
+        protected override IndexerExpression? Transform(CallExpression call)
         {
             // If we hit a wildcard-compatible operation, then any wildcards within its operands "belong" to
             // it and can't be the result of this search.
-            if (Operators.WildcardComparators.Contains(lx.OperatorName))
+            if (Operators.WildcardComparators.Contains(call.OperatorName))
                 return null;
     
-            return lx.Operands.Select(Transform).FirstOrDefault(e => e != null);
+            return call.Operands.Select(Transform).FirstOrDefault(e => e != null);
         }
 
         protected override IndexerExpression? Transform(IndexOfMatchExpression mx)

--- a/src/Serilog.Expressions/Expressions/NameResolver.cs
+++ b/src/Serilog.Expressions/Expressions/NameResolver.cs
@@ -34,6 +34,24 @@ namespace Serilog.Expressions
         /// and accept parameters of type <see cref="LogEventPropertyValue"/>. If the <c>ci</c> modifier is supported,
         /// a <see cref="StringComparison"/> should be included in the argument list. If the function is culture-specific,
         /// an <see cref="IFormatProvider"/> should be included in the argument list.</remarks>
-        public abstract bool TryResolveFunctionName(string name, [MaybeNullWhen(false)] out MethodInfo implementation);
+        public virtual bool TryResolveFunctionName(string name, [MaybeNullWhen(false)] out MethodInfo implementation)
+        {
+            implementation = null;
+            return false;
+        }
+
+        /// <summary>
+        /// Provide a value for a non-<see cref="LogEventPropertyValue"/> parameter. This allows user-defined state to
+        /// be threaded through user-defined functions.
+        /// </summary>
+        /// <param name="parameter">A parameter of a method implementing a user-defined function, which could not be
+        /// bound to any of the standard runtime-provided values or operands.</param>
+        /// <param name="boundValue">The value that should be provided when the method is called.</param>
+        /// <returns><c>True</c> if the parameter could be bound; otherwise, <c>false</c>.</returns>
+        public virtual bool TryBindFunctionParameter(ParameterInfo parameter, [MaybeNullWhen(false)] out object boundValue)
+        {
+            boundValue = null;
+            return false;
+        }
     }
 }

--- a/src/Serilog.Expressions/Serilog.Expressions.csproj
+++ b/src/Serilog.Expressions/Serilog.Expressions.csproj
@@ -29,9 +29,5 @@
   <ItemGroup>
     <None Include="..\..\assets\icon.png" Pack="true" Visible="false" PackagePath="" />
   </ItemGroup>
-  
-  <ItemGroup>
-    <Folder Include="Templates\Runtime" />
-  </ItemGroup>
 
 </Project>

--- a/src/Serilog.Expressions/Serilog.Expressions.csproj
+++ b/src/Serilog.Expressions/Serilog.Expressions.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>An embeddable mini-language for filtering, enriching, and formatting Serilog
       events, ideal for use with JSON or XML configuration.</Description>
-    <VersionPrefix>3.0.0</VersionPrefix>
+    <VersionPrefix>3.1.0</VersionPrefix>
     <Authors>Serilog Contributors</Authors>
     <TargetFrameworks>netstandard2.0;netstandard2.1;net5.0</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -28,6 +28,10 @@
   
   <ItemGroup>
     <None Include="..\..\assets\icon.png" Pack="true" Visible="false" PackagePath="" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <Folder Include="Templates\Runtime" />
   </ItemGroup>
 
 </Project>

--- a/src/Serilog.Expressions/Templates/Compilation/TemplateFunctionNameResolver.cs
+++ b/src/Serilog.Expressions/Templates/Compilation/TemplateFunctionNameResolver.cs
@@ -1,0 +1,40 @@
+﻿// Copyright © Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.Generic;
+using Serilog.Expressions;
+using Serilog.Expressions.Compilation;
+using Serilog.Expressions.Runtime;
+using Serilog.Templates.Ast;
+using Serilog.Templates.Compilation.UnreferencedProperties;
+
+namespace Serilog.Templates.Compilation
+{
+    static class TemplateFunctionNameResolver
+    {
+        public static NameResolver Build(NameResolver? additionalNameResolver, Template template)
+        {
+            var resolvers = new List<NameResolver>
+            {
+                new StaticMemberNameResolver(typeof(RuntimeOperators)),
+                new UnreferencedPropertiesFunction(template)
+            };
+            
+            if (additionalNameResolver != null)
+                resolvers.Add(additionalNameResolver);
+            
+            return new OrderedNameResolver(resolvers);
+        }
+    }
+}

--- a/src/Serilog.Expressions/Templates/Compilation/UnreferencedProperties/ExpressionReferencedPropertiesFinder.cs
+++ b/src/Serilog.Expressions/Templates/Compilation/UnreferencedProperties/ExpressionReferencedPropertiesFinder.cs
@@ -1,0 +1,92 @@
+﻿// Copyright © Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.Generic;
+using System.Linq;
+using Serilog.Expressions.Ast;
+using Serilog.Expressions.Compilation.Transformations;
+
+namespace Serilog.Templates.Compilation.UnreferencedProperties
+{
+    class ExpressionReferencedPropertiesFinder : SerilogExpressionTransformer<IEnumerable<string>>
+    {
+        public IEnumerable<string> FindReferencedProperties(Expression expression)
+        {
+            return Transform(expression);
+        }
+
+        protected override IEnumerable<string> Transform(CallExpression call)
+        {
+            return call.Operands.SelectMany(Transform);
+        }
+
+        protected override IEnumerable<string> Transform(ConstantExpression cx)
+        {
+            yield break;
+        }
+
+        protected override IEnumerable<string> Transform(AmbientNameExpression px)
+        {
+            if (!px.IsBuiltIn)
+                yield return px.PropertyName;
+        }
+
+        protected override IEnumerable<string> Transform(LocalNameExpression nlx)
+        {
+            yield break;
+        }
+
+        protected override IEnumerable<string> Transform(AccessorExpression spx)
+        {
+            return Transform(spx.Receiver);
+        }
+
+        protected override IEnumerable<string> Transform(LambdaExpression lmx)
+        {
+            return Transform(lmx.Body);
+        }
+
+        protected override IEnumerable<string> Transform(ParameterExpression prx)
+        {
+            yield break;
+        }
+
+        protected override IEnumerable<string> Transform(IndexerWildcardExpression wx)
+        {
+            yield break;
+        }
+
+        protected override IEnumerable<string> Transform(ArrayExpression ax)
+        {
+            return ax.Elements.OfType<ItemElement>().SelectMany(i => Transform(i.Value))
+                .Concat(ax.Elements.OfType<SpreadElement>().SelectMany(i => Transform(i.Content)));
+        }
+
+        protected override IEnumerable<string> Transform(ObjectExpression ox)
+        {
+            return ox.Members.OfType<PropertyMember>().SelectMany(m => Transform(m.Value))
+                .Concat(ox.Members.OfType<SpreadMember>().SelectMany(m => Transform(m.Content)));
+        }
+
+        protected override IEnumerable<string> Transform(IndexerExpression ix)
+        {
+            return Transform(ix.Index).Concat(Transform(ix.Receiver));
+        }
+
+        protected override IEnumerable<string> Transform(IndexOfMatchExpression mx)
+        {
+            return Transform(mx.Corpus);
+        }
+    }
+}

--- a/src/Serilog.Expressions/Templates/Compilation/UnreferencedProperties/TemplateReferencedPropertiesFinder.cs
+++ b/src/Serilog.Expressions/Templates/Compilation/UnreferencedProperties/TemplateReferencedPropertiesFinder.cs
@@ -1,0 +1,51 @@
+﻿// Copyright © Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Serilog.Templates.Ast;
+
+namespace Serilog.Templates.Compilation.UnreferencedProperties
+{
+    class TemplateReferencedPropertiesFinder
+    {
+        readonly ExpressionReferencedPropertiesFinder _rpf = new();
+        
+        public IEnumerable<string> FindReferencedProperties(Template template)
+        {
+            return template switch
+            {
+                Conditional conditional => _rpf.FindReferencedProperties(conditional.Condition)
+                    .Concat(FindReferencedProperties(conditional.Consequent))
+                    .Concat(conditional.Alternative != null
+                        ? FindReferencedProperties(conditional.Alternative)
+                        : Enumerable.Empty<string>()),
+                FormattedExpression formattedExpression =>
+                    _rpf.FindReferencedProperties(formattedExpression.Expression),
+                LiteralText => Enumerable.Empty<string>(),
+                Repetition repetition => _rpf.FindReferencedProperties(repetition.Enumerable)
+                    .Concat(FindReferencedProperties(repetition.Body))
+                    .Concat(repetition.Alternative != null
+                        ? FindReferencedProperties(repetition.Alternative)
+                        : Enumerable.Empty<string>())
+                    .Concat(repetition.Delimiter != null
+                        ? FindReferencedProperties(repetition.Delimiter)
+                        : Enumerable.Empty<string>()),
+                TemplateBlock templateBlock => templateBlock.Elements.SelectMany(FindReferencedProperties),
+                _ => throw new ArgumentOutOfRangeException(nameof(template))
+            };
+        }
+    }
+}

--- a/src/Serilog.Expressions/Templates/Compilation/UnreferencedProperties/UnreferencedPropertiesFunction.cs
+++ b/src/Serilog.Expressions/Templates/Compilation/UnreferencedProperties/UnreferencedPropertiesFunction.cs
@@ -1,0 +1,99 @@
+﻿// Copyright © Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Reflection;
+using Serilog.Events;
+using Serilog.Expressions;
+using Serilog.Parsing;
+using Serilog.Templates.Ast;
+
+namespace Serilog.Templates.Compilation.UnreferencedProperties
+{
+    /// <summary>
+    /// This little extension implements the <c>rest()</c> function in expression templates. It's based on
+    /// <c>Serilog.Sinks.SystemConsole.PropertiesTokenRenderer</c>, and is equivalent to how <c>Properties</c> is rendered by
+    /// the console sink. <c>rest()</c> will return a structure containing all of the user-defined properties from a
+    /// log event except those referenced in either the event's message template, or the expression template itself.
+    /// </summary>
+    /// <remarks>
+    /// The existing semantics of <c>Properties</c> in output templates isn't suitable for expression templates. The
+    /// <c>@p</c> object provides access to <em>all</em> event properties in an expression template, so it would make no
+    /// sense to render that object without all of its members.
+    /// </remarks>
+    class UnreferencedPropertiesFunction : NameResolver
+    {
+        const string FunctionName = "rest";
+        
+        readonly HashSet<string> _referencedInTemplate;
+
+        public UnreferencedPropertiesFunction(Template template)
+        {
+            var finder = new TemplateReferencedPropertiesFinder();
+            _referencedInTemplate = new HashSet<string>(finder.FindReferencedProperties(template));
+        }
+
+        public override bool TryBindFunctionParameter(ParameterInfo parameter, [MaybeNullWhen(false)] out object boundValue)
+        {
+            if (parameter.ParameterType == typeof(UnreferencedPropertiesFunction))
+            {
+                boundValue = this;
+                return true;
+            }
+
+            boundValue = null;
+            return false;
+        }
+
+        public override bool TryResolveFunctionName(string name, [MaybeNullWhen(false)] out MethodInfo implementation)
+        {
+            if (name.Equals(FunctionName, StringComparison.OrdinalIgnoreCase))
+            {
+                implementation = typeof(UnreferencedPropertiesFunction).GetMethod(nameof(Implementation),
+                    BindingFlags.Static | BindingFlags.Public)!;
+                return true;
+            }
+
+            implementation = null;
+            return false;
+        }
+
+        // By convention, built-in functions accept and return nullable values.
+        // ReSharper disable once ReturnTypeCanBeNotNullable
+        public static LogEventPropertyValue? Implementation(UnreferencedPropertiesFunction self, LogEvent logEvent)
+        {
+            return new StructureValue(logEvent.Properties
+                .Where(kvp => !(self._referencedInTemplate.Contains(kvp.Key) ||
+                                TemplateContainsPropertyName(logEvent.MessageTemplate, kvp.Key)))
+                .Select(kvp => new LogEventProperty(kvp.Key, kvp.Value)));
+        }
+
+        static bool TemplateContainsPropertyName(MessageTemplate messageTemplate, string propertyName)
+        {
+            foreach (var token in messageTemplate.Tokens)
+            {
+                if (token is PropertyToken namedProperty &&
+                    namedProperty.PropertyName == propertyName)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/Serilog.Expressions/Templates/ExpressionTemplate.cs
+++ b/src/Serilog.Expressions/Templates/ExpressionTemplate.cs
@@ -86,7 +86,8 @@ namespace Serilog.Templates
             result = new ExpressionTemplate(
                 TemplateCompiler.Compile(
                     planned,
-                    formatProvider, DefaultFunctionNameResolver.Build(nameResolver),
+                    formatProvider,
+                    TemplateFunctionNameResolver.Build(nameResolver, planned),
                     SelectTheme(theme, applyThemeWhenOutputIsRedirected)));
             
             return true;
@@ -126,7 +127,7 @@ namespace Serilog.Templates
             _compiled = TemplateCompiler.Compile(
                 planned,
                 formatProvider,
-                DefaultFunctionNameResolver.Build(nameResolver),
+                TemplateFunctionNameResolver.Build(nameResolver, planned),
                 SelectTheme(theme, applyThemeWhenOutputIsRedirected));
         }
 

--- a/test/Serilog.Expressions.Tests/Expressions/NameResolverTests.cs
+++ b/test/Serilog.Expressions.Tests/Expressions/NameResolverTests.cs
@@ -1,7 +1,11 @@
-﻿using Serilog.Events;
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using Serilog.Events;
 using Serilog.Expressions.Runtime;
 using Serilog.Expressions.Tests.Support;
 using Xunit;
+
+#nullable enable
 
 namespace Serilog.Expressions.Tests.Expressions
 {
@@ -15,12 +19,56 @@ namespace Serilog.Expressions.Tests.Expressions
             return new ScalarValue(num + 42);
         }
 
+        public static LogEventPropertyValue? SecretWordAt(string word, LogEventPropertyValue? index)
+        {
+            if (!Coerce.Numeric(index, out var i))
+                return null;
+            
+            return new ScalarValue(word[(int)i].ToString());
+        }
+
+        class SecretWordResolver : NameResolver
+        {
+            readonly NameResolver _inner;
+            readonly string _word;
+
+            public SecretWordResolver(NameResolver inner, string word)
+            {
+                _inner = inner;
+                _word = word;
+            }
+
+            public override bool TryResolveFunctionName(string name, [MaybeNullWhen(false)] out MethodInfo implementation)
+                => _inner.TryResolveFunctionName(name, out implementation);
+
+            public override bool TryBindFunctionParameter(ParameterInfo parameter, [MaybeNullWhen(false)] out object boundValue)
+            {
+                if (parameter.ParameterType == typeof(string))
+                {
+                    boundValue = _word;
+                    return true;
+                }
+
+                boundValue = null;
+                return false;
+            }
+        }
+
         [Fact]
         public void UserDefinedFunctionsAreCallableInExpressions()
         {
             var expr = SerilogExpression.Compile(
                 "magic(10) + 3 = 55",
                 nameResolver: new StaticMemberNameResolver(typeof(NameResolverTests)));
+            Assert.True(Coerce.IsTrue(expr(Some.InformationEvent())));
+        }
+        
+        [Fact]
+        public void UserDefinedFunctionsCanReceiveUserProvidedParameters()
+        {
+            var expr = SerilogExpression.Compile(
+                "SecretWordAt(1) = 'e'",
+                nameResolver: new SecretWordResolver(new StaticMemberNameResolver(typeof(NameResolverTests)), "hello"));
             Assert.True(Coerce.IsTrue(expr(Some.InformationEvent())));
         }
     }

--- a/test/Serilog.Expressions.Tests/Templates/UnreferencedPropertiesFunctionTests.cs
+++ b/test/Serilog.Expressions.Tests/Templates/UnreferencedPropertiesFunctionTests.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using Serilog.Events;
+using Serilog.Parsing;
+using Serilog.Templates.Ast;
+using Serilog.Templates.Compilation.UnreferencedProperties;
+using Serilog.Templates.Parsing;
+using Xunit;
+
+namespace Serilog.Expressions.Tests.Templates
+{
+    public class UnreferencedPropertiesFunctionTests
+    {
+        [Fact]
+        public void UnreferencedPropertiesFunctionIsNamedRest()
+        {
+            var function = new UnreferencedPropertiesFunction(new LiteralText("test"));
+            Assert.True(function.TryResolveFunctionName("Rest", out _));
+        }
+
+        [Fact]
+        public void UnreferencedPropertiesExcludeThoseInMessageAndTemplate()
+        {
+            Assert.True(new TemplateParser().TryParse("{A + 1}{#if true}{B}{#end}", out var template, out _));
+            
+            var function = new UnreferencedPropertiesFunction(template!);
+            
+            var evt = new LogEvent(
+                DateTimeOffset.Now,
+                LogEventLevel.Debug,
+                null,
+                new MessageTemplate(new[] {new PropertyToken("C", "{C}")}),
+                new[]
+                {
+                    new LogEventProperty("A", new ScalarValue(null)),
+                    new LogEventProperty("B", new ScalarValue(null)),
+                    new LogEventProperty("C", new ScalarValue(null)),
+                    new LogEventProperty("D", new ScalarValue(null)),
+                });
+
+            var result = UnreferencedPropertiesFunction.Implementation(function, evt);
+            
+            var sv = Assert.IsType<StructureValue>(result);
+            var included = Assert.Single(sv.Properties);
+            Assert.Equal("D", included!.Name);
+        }
+    }
+}


### PR DESCRIPTION
 * Allow all functions to accept a `LogEvent` parameter
 * Adds virtual `NameResolver.TryBindFunctionParameter()` to support user-defined  function parameter types
 * Combine these to implement a `Rest()` function, usable in templates only, that matches the behavior of `{Properties}` in Serilog output templates (i.e. all properties not referenced elsewhere in the template or message)
 * Bump version to 3.1.0 (added feature)

With this one I think we're _finally_ feature-complete.