### PR TITLE
Default `rest()` to ignore message templates by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ The built-in properties mirror those available in the CLEF format.
 | Array | An array of values, in square brackets | `[1, 'two', null]` |
 | Object | A mapping of string keys to values; keys that are valid identifiers do not need to be quoted | `{a: 1, 'b c': 2, d}` |
 
-Array and object literals support the spread operator: `[1, 2, ..rest]`, `{a: 1, ..other}`. Specifying an undefined
+Array and object literals support the spread operator: `[1, 2, ..others]`, `{a: 1, ..others}`. Specifying an undefined
 property in an object literal will remove it from the result: `{..User, Email: Undefined()}`
 
 ### Operators and conditionals
@@ -196,7 +196,7 @@ calling a function will be undefined if:
 | `LastIndexOf(s, t)` | Returns the last index of substring `t` in string `s`, or -1 if the substring does not appear. |
 | `Length(x)` | Returns the length of a string or array. |
 | `Now()` | Returns `DateTimeOffset.Now`. |
-| `Rest()` | In an `ExpressionTemplate`, returns an object containing the first-class event properties not otherwise referenced in the template or the event's message. |
+| `Rest([deep])` | In an `ExpressionTemplate`, returns an object containing the first-class event properties not otherwise referenced in the template. If `deep` is `true`, also excludes properties referenced in the event's message template. |
 | `Round(n, m)` | Round the number `n` to `m` decimal places. |
 | `StartsWith(s, t)` | Tests whether the string `s` starts with substring `t`. |
 | `Substring(s, start, [length])` | Return the substring of string `s` from `start` to the end of the string, or of `length` characters, if this argument is supplied. |

--- a/src/Serilog.Expressions/Expressions/Compilation/Variadics/VariadicCallRewriter.cs
+++ b/src/Serilog.Expressions/Expressions/Compilation/Variadics/VariadicCallRewriter.cs
@@ -30,20 +30,11 @@ namespace Serilog.Expressions.Compilation.Variadics
 
         protected override Expression Transform(CallExpression call)
         {
-            if (Operators.SameOperator(call.OperatorName, Operators.OpSubstring) && call.Operands.Length == 2)
-            {
-                var operands = call.Operands
-                    .Select(Transform)
-                    .Concat(new[] {CallUndefined()})
-                    .ToArray();
-                return new CallExpression(call.IgnoreCase, call.OperatorName, operands);
-            }
-
             if (Operators.SameOperator(call.OperatorName, Operators.OpCoalesce) ||
                 Operators.SameOperator(call.OperatorName, Operators.OpConcat))
             {
                 if (call.Operands.Length == 0)
-                    return CallUndefined();
+                    return new CallExpression(false, Operators.OpUndefined);
                 if (call.Operands.Length == 1)
                     return Transform(call.Operands.Single());
                 if (call.Operands.Length > 2)
@@ -54,18 +45,7 @@ namespace Serilog.Expressions.Compilation.Variadics
                 }
             }
 
-            if (Operators.SameOperator(call.OperatorName, Operators.OpToString) &&
-                call.Operands.Length == 1)
-            {
-                return new CallExpression(call.IgnoreCase, call.OperatorName, call.Operands[0], CallUndefined());
-            }
-
             return base.Transform(call);
-        }
-
-        static CallExpression CallUndefined()
-        {
-            return new(false, Operators.OpUndefined);
         }
     }
 }

--- a/src/Serilog.Expressions/Expressions/Runtime/RuntimeOperators.cs
+++ b/src/Serilog.Expressions/Expressions/Runtime/RuntimeOperators.cs
@@ -236,9 +236,9 @@ namespace Serilog.Expressions.Runtime
             return null;
         }
 
-        public static LogEventPropertyValue? Round(LogEventPropertyValue? value, LogEventPropertyValue? places)
+        public static LogEventPropertyValue? Round(LogEventPropertyValue? number, LogEventPropertyValue? places)
         {
-            if (!Coerce.Numeric(value, out var v) ||
+            if (!Coerce.Numeric(number, out var v) ||
                 !Coerce.Numeric(places, out var p) ||
                 p < 0 ||
                 p > 32) // Check my memory, here :D
@@ -266,57 +266,57 @@ namespace Serilog.Expressions.Runtime
                 null;
         }
 
-        public static LogEventPropertyValue? Contains(StringComparison sc, LogEventPropertyValue? corpus, LogEventPropertyValue? pattern)
+        public static LogEventPropertyValue? Contains(StringComparison sc, LogEventPropertyValue? @string, LogEventPropertyValue? substring)
         {
-            if (!Coerce.String(corpus, out var ctx) ||
-                !Coerce.String(pattern, out var ptx))
+            if (!Coerce.String(@string, out var ctx) ||
+                !Coerce.String(substring, out var ptx))
                 return null;
 
             return ScalarBoolean(ctx.Contains(ptx, sc));
         }
 
-        public static LogEventPropertyValue? IndexOf(StringComparison sc, LogEventPropertyValue? corpus, LogEventPropertyValue? pattern)
+        public static LogEventPropertyValue? IndexOf(StringComparison sc, LogEventPropertyValue? @string, LogEventPropertyValue? substring)
         {
-            if (!Coerce.String(corpus, out var ctx) ||
-                !Coerce.String(pattern, out var ptx))
+            if (!Coerce.String(@string, out var ctx) ||
+                !Coerce.String(substring, out var ptx))
                 return null;
 
             return new ScalarValue(ctx.IndexOf(ptx, sc));
         }
 
-        public static LogEventPropertyValue? LastIndexOf(StringComparison sc, LogEventPropertyValue? corpus, LogEventPropertyValue? pattern)
+        public static LogEventPropertyValue? LastIndexOf(StringComparison sc, LogEventPropertyValue? @string, LogEventPropertyValue? substring)
         {
-            if (!Coerce.String(corpus, out var ctx) ||
-                !Coerce.String(pattern, out var ptx))
+            if (!Coerce.String(@string, out var ctx) ||
+                !Coerce.String(substring, out var ptx))
                 return null;
 
             return new ScalarValue(ctx.LastIndexOf(ptx, sc));
         }
 
-        public static LogEventPropertyValue? Length(LogEventPropertyValue? arg)
+        public static LogEventPropertyValue? Length(LogEventPropertyValue? value)
         {
-            if (Coerce.String(arg, out var s))
+            if (Coerce.String(value, out var s))
                 return new ScalarValue(s.Length);
 
-            if (arg is SequenceValue seq)
+            if (value is SequenceValue seq)
                 return new ScalarValue(seq.Elements.Count);
 
             return null;
         }
 
-        public static LogEventPropertyValue? StartsWith(StringComparison sc, LogEventPropertyValue? corpus, LogEventPropertyValue? pattern)
+        public static LogEventPropertyValue? StartsWith(StringComparison sc, LogEventPropertyValue? value, LogEventPropertyValue? substring)
         {
-            if (!Coerce.String(corpus, out var ctx) ||
-                !Coerce.String(pattern, out var ptx))
+            if (!Coerce.String(value, out var ctx) ||
+                !Coerce.String(substring, out var ptx))
                 return null;
 
             return ScalarBoolean(ctx.StartsWith(ptx, sc));
         }
 
-        public static LogEventPropertyValue? EndsWith(StringComparison sc, LogEventPropertyValue? corpus, LogEventPropertyValue? pattern)
+        public static LogEventPropertyValue? EndsWith(StringComparison sc, LogEventPropertyValue? value, LogEventPropertyValue? substring)
         {
-            if (!Coerce.String(corpus, out var ctx) ||
-                !Coerce.String(pattern, out var ptx))
+            if (!Coerce.String(value, out var ctx) ||
+                !Coerce.String(substring, out var ptx))
                 return null;
 
             return ScalarBoolean(ctx.EndsWith(ptx, sc));
@@ -432,17 +432,17 @@ namespace Serilog.Expressions.Runtime
         }
 
         // Ideally this will be compiled as a short-circuiting intrinsic
-        public static LogEventPropertyValue? Coalesce(LogEventPropertyValue? v1, LogEventPropertyValue? v2)
+        public static LogEventPropertyValue? Coalesce(LogEventPropertyValue? value0, LogEventPropertyValue? value1)
         {
-            if (v1 is null or ScalarValue {Value: null})
-                return v2;
+            if (value0 is null or ScalarValue {Value: null})
+                return value1;
 
-            return v1;
+            return value0;
         }
 
-        public static LogEventPropertyValue? Substring(LogEventPropertyValue? sval, LogEventPropertyValue? startIndex, LogEventPropertyValue? length)
+        public static LogEventPropertyValue? Substring(LogEventPropertyValue? @string, LogEventPropertyValue? startIndex, LogEventPropertyValue? length = null)
         {
-            if (!Coerce.String(sval, out var str) ||
+            if (!Coerce.String(@string, out var str) ||
                 !Coerce.Numeric(startIndex, out var si))
                 return null;
             
@@ -461,9 +461,9 @@ namespace Serilog.Expressions.Runtime
             return new ScalarValue(str.Substring((int)si, (int)len));
         }
 
-        public static LogEventPropertyValue? Concat(LogEventPropertyValue? first, LogEventPropertyValue? second)
+        public static LogEventPropertyValue? Concat(LogEventPropertyValue? string0, LogEventPropertyValue? string1)
         {
-            if (Coerce.String(first, out var f) && Coerce.String(second, out var s))
+            if (Coerce.String(string0, out var f) && Coerce.String(string1, out var s))
             {
                 return new ScalarValue(f + s);
             }
@@ -492,7 +492,7 @@ namespace Serilog.Expressions.Runtime
             return Coerce.IsTrue(condition) ? consequent : alternative;
         }
 
-        public static LogEventPropertyValue? ToString(IFormatProvider? formatProvider, LogEventPropertyValue? value, LogEventPropertyValue? format)
+        public static LogEventPropertyValue? ToString(IFormatProvider? formatProvider, LogEventPropertyValue? value, LogEventPropertyValue? format = null)
         {
             if (value is not ScalarValue sv ||
                 sv.Value == null ||

--- a/src/Serilog.Expressions/Templates/Compilation/UnreferencedProperties/UnreferencedPropertiesFunction.cs
+++ b/src/Serilog.Expressions/Templates/Compilation/UnreferencedProperties/UnreferencedPropertiesFunction.cs
@@ -19,6 +19,7 @@ using System.Linq;
 using System.Reflection;
 using Serilog.Events;
 using Serilog.Expressions;
+using Serilog.Expressions.Runtime;
 using Serilog.Parsing;
 using Serilog.Templates.Ast;
 
@@ -74,11 +75,12 @@ namespace Serilog.Templates.Compilation.UnreferencedProperties
 
         // By convention, built-in functions accept and return nullable values.
         // ReSharper disable once ReturnTypeCanBeNotNullable
-        public static LogEventPropertyValue? Implementation(UnreferencedPropertiesFunction self, LogEvent logEvent)
+        public static LogEventPropertyValue? Implementation(UnreferencedPropertiesFunction self, LogEvent logEvent, LogEventPropertyValue? deep = null)
         {
+            var checkMessageTemplate = Coerce.IsTrue(deep);
             return new StructureValue(logEvent.Properties
-                .Where(kvp => !(self._referencedInTemplate.Contains(kvp.Key) ||
-                                TemplateContainsPropertyName(logEvent.MessageTemplate, kvp.Key)))
+                .Where(kvp => !self._referencedInTemplate.Contains(kvp.Key) &&
+                                (!checkMessageTemplate || !TemplateContainsPropertyName(logEvent.MessageTemplate, kvp.Key)))
                 .Select(kvp => new LogEventProperty(kvp.Key, kvp.Value)));
         }
 

--- a/test/Serilog.Expressions.Tests/Cases/template-evaluation-cases.asv
+++ b/test/Serilog.Expressions.Tests/Cases/template-evaluation-cases.asv
@@ -27,3 +27,6 @@ A{#if false}B{#else if true}C{#end}                  ⇶ AC
 {#if true}A{#each a in [1]}B{a}{#end}C{#end}D        ⇶ AB1CD
 {#each a in []}{a}!{#else}none{#end}                 ⇶ none
 Culture-specific {42.34}                             ⇶ Culture-specific 42,34
+{rest()}                                             ⇶ {"Name":"nblumhardt"}
+{Name} {rest()}                                      ⇶ nblumhardt {}
+{rest(true)}                                         ⇶ {}

--- a/test/Serilog.Expressions.Tests/ExpressionCompilerTests.cs
+++ b/test/Serilog.Expressions.Tests/ExpressionCompilerTests.cs
@@ -1,4 +1,5 @@
-﻿using Serilog.Events;
+﻿using System;
+using Serilog.Events;
 using System.Linq;
 using Serilog.Expressions.Tests.Support;
 using Xunit;
@@ -132,6 +133,19 @@ namespace Serilog.Expressions.Tests
                 Some.InformationEvent("{Numbers}", new []{1, 2, 3}),
                 Some.InformationEvent("{Numbers}", new [] { 1, 5, 3 }),
                 Some.InformationEvent());
+        }
+
+        [Theory]
+        [InlineData("now(1)", "The function `now` accepts no arguments.")]
+        [InlineData("length()", "The function `length` accepts one argument, `value`.")]
+        [InlineData("length(1, 2)", "The function `length` accepts one argument, `value`.")]
+        [InlineData("round()", "The function `round` accepts two arguments, `number` and `places`.")]
+        [InlineData("substring()", "The function `substring` accepts arguments `string`, `startIndex`, and `length` (optional).")]
+        public void ReportsArityMismatches(string call, string expectedError)
+        {
+            // These will eventually be reported gracefully by `TryCompile()`...
+            var ex = Assert.Throws<ArgumentException>(() => SerilogExpression.Compile(call));
+            Assert.Equal(expectedError, ex.Message);
         }
 
         static void AssertEvaluation(string expression, LogEvent match, params LogEvent[] noMatches)


### PR DESCRIPTION
This is not always desirable behavior, and since it has a perf cost, it might as well be the opt-in:

| Function | Description |
| :--- | :--- |
| `Rest([deep])` | In an `ExpressionTemplate`, returns an object containing the first-class event properties not otherwise referenced in the template. If `deep` is `true`, also excludes properties referenced in the event's message template. |

`LinqExpressionCompiler` now uses method argument names and default values when binding function calls, so user-defined functions can have optional arguments, and we don't have to add custom rewrite rules for every function with optional args.