### PR TITLE
Update Readme: Fix up example for custom NameResolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,7 +381,7 @@ User-defined functions are supplied through an instance of `NameResolver`:
 
 ```csharp
 var myFunctions = new StaticMemberNameResolver(typeof(MyFunctions));
-var expr = SerilogExpression.Compile("IsHello(User.Name)", new[] { myFunctions });
+var expr = SerilogExpression.Compile("IsHello(User.Name)", nameResolver: customSerilogFunctions);
 // Filter events based on whether `User.Name` is `'Hello'` :-)
 ```
 


### PR DESCRIPTION
I tried the example code from the readme and could not get it to work as it does not expect an array for nameResolver