### PR TITLE
Backport Has() function from Serilog.Filters.Expressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ calling a function will be undefined if:
 | `IndexOf(s, t)` | Returns the first index of substring `t` in string `s`, or -1 if the substring does not appear. |
 | `IndexOfMatch(s, p)` | Returns the index of the first match of regular expression `p` in string `s`, or -1 if the regular expression does not match. |
 | `IsMatch(s, p)` | Tests whether the regular expression `p` matches within the string `s`. |
-| `IsDefined(x)` | Returns `true` if the expression `x` has a value, including `null`, or `false` if `x` is undefined. |
+| `IsDefined(x)` | Returns `true` if the expression `x` has a value, including `null`, or `false` if `x` is undefined. If coming from Serilog.Filters.Expressions depercated package this was previously called Has() |
 | `LastIndexOf(s, t)` | Returns the last index of substring `t` in string `s`, or -1 if the substring does not appear. |
 | `Length(x)` | Returns the length of a string or array. |
 | `Now()` | Returns `DateTimeOffset.Now`. |

--- a/src/Serilog.Expressions/Expressions/Runtime/RuntimeOperators.cs
+++ b/src/Serilog.Expressions/Expressions/Runtime/RuntimeOperators.cs
@@ -327,6 +327,15 @@ namespace Serilog.Expressions.Runtime
             return ScalarBoolean(value != null);
         }
 
+        /// <summary>
+        /// Used to backport anyone coming from Serilog.Filters.Expressions that used Has()
+        /// Before it was renamed to IsDefined()
+        /// </summary>
+        public static LogEventPropertyValue Has(LogEventPropertyValue? value)
+        {
+            return IsDefined(value);
+        }
+
         public static LogEventPropertyValue? ElementAt(StringComparison sc, LogEventPropertyValue? items, LogEventPropertyValue? index)
         {
             // ReSharper disable once ConvertIfStatementToSwitchStatement

--- a/test/Serilog.Expressions.Tests/Cases/template-evaluation-cases.asv
+++ b/test/Serilog.Expressions.Tests/Cases/template-evaluation-cases.asv
@@ -30,3 +30,6 @@ Culture-specific {42.34}                             ⇶ Culture-specific 42,34
 {rest()}                                             ⇶ {"Name":"nblumhardt"}
 {Name} {rest()}                                      ⇶ nblumhardt {}
 {rest(true)}                                         ⇶ {}
+{Name}												 ⇶ nblumhardt
+{IsDefined(Name)}									 ⇶ True
+{IsDefined(NonExistantProperty)}					 ⇶ False

--- a/test/Serilog.Expressions.Tests/Cases/template-evaluation-cases.asv
+++ b/test/Serilog.Expressions.Tests/Cases/template-evaluation-cases.asv
@@ -31,5 +31,9 @@ Culture-specific {42.34}                             ⇶ Culture-specific 42,34
 {Name} {rest()}                                      ⇶ nblumhardt {}
 {rest(true)}                                         ⇶ {}
 {Name}												 ⇶ nblumhardt
+{Name = 'nblumhardt'}								 ⇶ True
+{Name = 'jdoe'}										 ⇶ False
 {IsDefined(Name)}									 ⇶ True
 {IsDefined(NonExistantProperty)}					 ⇶ False
+{Has(Name)}											 ⇶ True
+{Has(NonExistantProperty)}							 ⇶ False


### PR DESCRIPTION
For users porting over from the deprecated `Serilog.Filters.Expressions` package. This keeps some feature parity in the template expressions.

This simply adds the `Has()` function which in turn is calling the new/renamed function of `IsDefined()`
Adds some tests to ensure the template expression works as expected.

Let me know if you are happy to accept this PR @nblumhardt to fix #64 