### PR TITLE
Backport explicit Property Names such as @Excepetion

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,12 +124,12 @@ using object literals:
 The following properties are available in expressions:
 
  * **All first-class properties of the event** - no special syntax: `SourceContext` and `Cart` are used in the formatting examples above
- * `@t` - the event's timestamp, as a `DateTimeOffset`
- * `@m` - the rendered message
- * `@mt` - the raw message template
- * `@l` - the event's level, as a `LogEventLevel`
- * `@x` - the exception associated with the event, if any, as an `Exception`
- * `@p` - a dictionary containing all first-class properties; this supports properties with non-identifier names, for example `@p['snake-case-name']`
+ * `@t` or `@TimeStamp` - the event's timestamp, as a `DateTimeOffset`
+ * `@m` or `@Message` - the rendered message
+ * `@mt` or `@MessageTemplate` - the raw message template
+ * `@l` or `@Level` - the event's level, as a `LogEventLevel`
+ * `@x` @or `@Exception` - the exception associated with the event, if any, as an `Exception`
+ * `@p` or `@Properties` - a dictionary containing all first-class properties; this supports properties with non-identifier names, for example `@p['snake-case-name']`
  * `@i` - event id; a 32-bit numeric hash of the event's message template
  * `@r` - renderings; if any tokens in the message template include .NET-specific formatting, an array of rendered values for each such token
 

--- a/src/Serilog.Expressions/Expressions/BuiltInProperty.cs
+++ b/src/Serilog.Expressions/Expressions/BuiltInProperty.cs
@@ -25,5 +25,15 @@ namespace Serilog.Expressions
         public const string Properties = "p";
         public const string Renderings = "r";
         public const string EventId = "i";
+
+        // These were the friendlier names that was available in
+        // Serilog.Filters.Expressions
+        public const string ExceptionExplicit = "Exception";
+        public const string LevelExplicit = "Level";
+        public const string TimestampExplicit = "Timestamp";
+        public const string MessageExplicit = "Message";
+        public const string MessageTemplateExplicit = "MessageTemplate";
+        public const string PropertiesExplicit = "Properties";
+        
     }
 }

--- a/src/Serilog.Expressions/Expressions/Compilation/Linq/LinqExpressionCompiler.cs
+++ b/src/Serilog.Expressions/Expressions/Compilation/Linq/LinqExpressionCompiler.cs
@@ -207,14 +207,29 @@ namespace Serilog.Expressions.Compilation.Linq
                 return px.PropertyName switch
                 {
                     BuiltInProperty.Level => Splice(context => new ScalarValue(context.LogEvent.Level)),
+                    BuiltInProperty.LevelExplicit => Splice(context => new ScalarValue(context.LogEvent.Level)),
+
                     BuiltInProperty.Message => Splice(context => new ScalarValue(Intrinsics.RenderMessage(formatter, context))),
+                    BuiltInProperty.MessageExplicit => Splice(context => new ScalarValue(Intrinsics.RenderMessage(formatter, context))),
+
                     BuiltInProperty.Exception => Splice(context =>
                         context.LogEvent.Exception == null ? null : new ScalarValue(context.LogEvent.Exception)),
+                    BuiltInProperty.ExceptionExplicit => Splice(context =>
+                        context.LogEvent.Exception == null ? null : new ScalarValue(context.LogEvent.Exception)),
+
                     BuiltInProperty.Timestamp => Splice(context => new ScalarValue(context.LogEvent.Timestamp)),
+                    BuiltInProperty.TimestampExplicit => Splice(context => new ScalarValue(context.LogEvent.Timestamp)),
+
                     BuiltInProperty.MessageTemplate => Splice(context => new ScalarValue(context.LogEvent.MessageTemplate.Text)),
+                    BuiltInProperty.MessageTemplateExplicit => Splice(context => new ScalarValue(context.LogEvent.MessageTemplate.Text)),
+
                     BuiltInProperty.Properties => Splice(context =>
                         new StructureValue(context.LogEvent.Properties.Select(kvp => new LogEventProperty(kvp.Key, kvp.Value)),
                             null)),
+                    BuiltInProperty.PropertiesExplicit => Splice(context =>
+                        new StructureValue(context.LogEvent.Properties.Select(kvp => new LogEventProperty(kvp.Key, kvp.Value)),
+                            null)),
+
                     BuiltInProperty.Renderings => Splice(context => Intrinsics.GetRenderings(context.LogEvent, formatProvider)),
                     BuiltInProperty.EventId => Splice(context =>
                         new ScalarValue(EventIdHash.Compute(context.LogEvent.MessageTemplate.Text))),

--- a/src/Serilog.Expressions/Templates/Compilation/TemplateCompiler.cs
+++ b/src/Serilog.Expressions/Templates/Compilation/TemplateCompiler.cs
@@ -33,6 +33,9 @@ namespace Serilog.Templates.Compilation
                 LiteralText text => new CompiledLiteralText(text.Text, theme),
                 FormattedExpression { Expression: AmbientNameExpression { IsBuiltIn: true, PropertyName: BuiltInProperty.Level} } level => new CompiledLevelToken(
                     level.Format, level.Alignment, theme),
+                FormattedExpression { Expression: AmbientNameExpression { IsBuiltIn: true, PropertyName: BuiltInProperty.LevelExplicit } } level => new CompiledLevelToken(
+                   level.Format, level.Alignment, theme),
+
                 FormattedExpression
                 {
                     Expression: AmbientNameExpression { IsBuiltIn: true, PropertyName: BuiltInProperty.Exception },
@@ -41,9 +44,22 @@ namespace Serilog.Templates.Compilation
                 } => new CompiledExceptionToken(theme),
                 FormattedExpression
                 {
+                    Expression: AmbientNameExpression { IsBuiltIn: true, PropertyName: BuiltInProperty.ExceptionExplicit },
+                    Alignment: null,
+                    Format: null
+                } => new CompiledExceptionToken(theme),
+
+                FormattedExpression
+                {
                     Expression: AmbientNameExpression { IsBuiltIn: true, PropertyName: BuiltInProperty.Message },
                     Format: null
                 } message => new CompiledMessageToken(formatProvider, message.Alignment, theme),
+                FormattedExpression
+                {
+                    Expression: AmbientNameExpression { IsBuiltIn: true, PropertyName: BuiltInProperty.MessageExplicit },
+                    Format: null
+                } message => new CompiledMessageToken(formatProvider, message.Alignment, theme),
+
                 FormattedExpression expression => new CompiledFormattedExpression(
                     ExpressionCompiler.Compile(expression.Expression, formatProvider, nameResolver), expression.Format, expression.Alignment, formatProvider, theme),
                 TemplateBlock block => new CompiledTemplateBlock(block.Elements.Select(e => Compile(e, formatProvider, nameResolver, theme)).ToArray()),

--- a/test/Serilog.Expressions.Tests/Cases/template-evaluation-cases.asv
+++ b/test/Serilog.Expressions.Tests/Cases/template-evaluation-cases.asv
@@ -1,9 +1,17 @@
 Hello, {'world'}!                        ⇶ Hello, world!
 {@l}                                     ⇶ Information
 {@l:u3}                                  ⇶ INF
+{@Level}								 ⇶ Information
+{@Level:u4}								 ⇶ INFO
+{@Level:w3}								 ⇶ inf
 Items are {[1, 2]}                       ⇶ Items are [1,2]
 Members are { {a: 1, 'b c': 2} }         ⇶ Members are {"a":1,"b c":2}
 {@p}                                     ⇶ {"Name":"nblumhardt"}
+{@p['Name']}                             ⇶ nblumhardt
+{@Properties}							 ⇶ {"Name":"nblumhardt"}
+{@Properties['Name']}					 ⇶ nblumhardt
+{@mt}									 ⇶ Hello, {Name}!
+{@MessageTemplate}						 ⇶ Hello, {Name}!
 Hello, {'my } brackety { {}} friends'}!  ⇶ Hello, my } brackety { {}} friends!
 Text only                                ⇶ Text only
 {{ Escaped {{ left {{                    ⇶ { Escaped { left {
@@ -13,6 +21,7 @@ Aligned {42,4}!                          ⇶ Aligned   42!
 Left {42,-4}!                            ⇶ Left 42  !
 Under width {42,0}!                      ⇶ Under width 42!
 {@m}                                     ⇶ Hello, nblumhardt!
+{@Message}								 ⇶ Hello, nblumhardt!
 Hello, {#if true}world{#end}!            ⇶ Hello, world!
 Hello, {#if true}w{42}d{#end}!           ⇶ Hello, w42d!
 Hello, {#if 1 = 1}world{#else}there{#end}!           ⇶ Hello, world!


### PR DESCRIPTION
This is to support porting over from Serilog.Filters.Expressions that supported more verbose/explicit names
Fixes #63 

```
@Message
@MessageTemplate
@Level
@Exception
@TimeStamp
@Properties
```

Note: I have not added more verbose names for `Renderings` and `EventId` as these were not present in Serilog.Filters.Expressions.
So I will leave it up to you @nblumhardt if you want to add or support them as well.

