### PR TITLE
Support aliasing of built-in property names (for Serilog.Filters.Expressions migration)

### DIFF
--- a/src/Serilog.Expressions/Expressions/Compilation/Arrays/ConstantArrayEvaluator.cs
+++ b/src/Serilog.Expressions/Expressions/Compilation/Arrays/ConstantArrayEvaluator.cs
@@ -23,7 +23,7 @@ namespace Serilog.Expressions.Compilation.Arrays
     {
         static readonly ConstantArrayEvaluator Instance = new ConstantArrayEvaluator();
 
-        public static Expression Evaluate(Expression expression)
+        public static Expression Rewrite(Expression expression)
         {
             return Instance.Transform(expression);
         }

--- a/src/Serilog.Expressions/Expressions/Compilation/ExpressionCompiler.cs
+++ b/src/Serilog.Expressions/Expressions/Compilation/ExpressionCompiler.cs
@@ -32,13 +32,12 @@ namespace Serilog.Expressions.Compilation
             actual = TextMatchingTransformer.Rewrite(actual);
             actual = LikeSyntaxTransformer.Rewrite(actual);
             actual = PropertiesObjectAccessorTransformer.Rewrite(actual);
-            actual = ConstantArrayEvaluator.Evaluate(actual);
-            actual = WildcardComprehensionTransformer.Expand(actual);
+            actual = ConstantArrayEvaluator.Rewrite(actual);
+            actual = WildcardComprehensionTransformer.Rewrite(actual);
             return actual;
         }
 
-        public static Evaluatable Compile(Expression expression, IFormatProvider? formatProvider,
-            NameResolver nameResolver)
+        public static Evaluatable Compile(Expression expression, IFormatProvider? formatProvider, NameResolver nameResolver)
         {
             var actual = Translate(expression);
             return LinqExpressionCompiler.Compile(actual, formatProvider, nameResolver);

--- a/src/Serilog.Expressions/Expressions/Compilation/Linq/LinqExpressionCompiler.cs
+++ b/src/Serilog.Expressions/Expressions/Compilation/Linq/LinqExpressionCompiler.cs
@@ -218,6 +218,8 @@ namespace Serilog.Expressions.Compilation.Linq
                     BuiltInProperty.Renderings => Splice(context => Intrinsics.GetRenderings(context.LogEvent, formatProvider)),
                     BuiltInProperty.EventId => Splice(context =>
                         new ScalarValue(EventIdHash.Compute(context.LogEvent.MessageTemplate.Text))),
+                    var alias when _nameResolver.TryResolveBuiltInPropertyName(alias, out var target) =>
+                        Transform(new AmbientNameExpression(target, true)),
                     _ => LX.Constant(null, typeof(LogEventPropertyValue))
                 };
             }

--- a/src/Serilog.Expressions/Expressions/Compilation/OrderedNameResolver.cs
+++ b/src/Serilog.Expressions/Expressions/Compilation/OrderedNameResolver.cs
@@ -51,5 +51,17 @@ namespace Serilog.Expressions.Compilation
             boundValue = null;
             return false;
         }
+
+        public override bool TryResolveBuiltInPropertyName(string alias, [NotNullWhen(true)] out string? target)
+        {
+            foreach (var resolver in _orderedResolvers)
+            {
+                if (resolver.TryResolveBuiltInPropertyName(alias, out target))
+                    return true;
+            }
+
+            target = null;
+            return false;
+        }
     }
 }

--- a/src/Serilog.Expressions/Expressions/Compilation/Wildcards/WildcardComprehensionTransformer.cs
+++ b/src/Serilog.Expressions/Expressions/Compilation/Wildcards/WildcardComprehensionTransformer.cs
@@ -22,7 +22,7 @@ namespace Serilog.Expressions.Compilation.Wildcards
     {
         int _nextParameter;
 
-        public static Expression Expand(Expression root)
+        public static Expression Rewrite(Expression root)
         {
             var wc = new WildcardComprehensionTransformer();
             return wc.Transform(root);

--- a/src/Serilog.Expressions/Expressions/NameResolver.cs
+++ b/src/Serilog.Expressions/Expressions/NameResolver.cs
@@ -53,5 +53,20 @@ namespace Serilog.Expressions
             boundValue = null;
             return false;
         }
+
+        /// <summary>
+        /// Map an unrecognized built-in property name to a recognised one.
+        /// </summary>
+        /// <remarks>Intended predominantly to support migration from <em>Serilog.Filters.Expressions</em>.</remarks>
+        /// <param name="alias">The unrecognized name, for example, <code>"Message"</code>; the <code>@</code> prefix is
+        /// not included.</param>
+        /// <param name="target">If the name could be resolved, the target property name, without any prefix; for
+        /// example, <code>"m"</code>.</param>
+        /// <returns>True if the alias was mapped to a built-in property; otherwise, false.</returns>
+        public virtual bool TryResolveBuiltInPropertyName(string alias, [NotNullWhen(true)] out string? target)
+        {
+            target = null;
+            return false;
+        }
     }
 }

--- a/test/Serilog.Expressions.Tests/Expressions/NameResolverTests.cs
+++ b/test/Serilog.Expressions.Tests/Expressions/NameResolverTests.cs
@@ -9,6 +9,7 @@ namespace Serilog.Expressions.Tests.Expressions
 {
     public class NameResolverTests
     {
+        // ReSharper disable once UnusedMember.Global
         public static LogEventPropertyValue? Magic(LogEventPropertyValue? number)
         {
             if (!Coerce.Numeric(number, out var num))
@@ -17,6 +18,7 @@ namespace Serilog.Expressions.Tests.Expressions
             return new ScalarValue(num + 42);
         }
 
+        // ReSharper disable once UnusedMember.Global
         public static LogEventPropertyValue? SecretWordAt(string word, LogEventPropertyValue? index)
         {
             if (!Coerce.Numeric(index, out var i))
@@ -52,6 +54,21 @@ namespace Serilog.Expressions.Tests.Expressions
             }
         }
 
+        class LegacyLevelPropertyNameResolver: NameResolver
+        {
+            public override bool TryResolveBuiltInPropertyName(string alias, [NotNullWhen(true)] out string? target)
+            {
+                if (alias == "Level")
+                {
+                    target = "l";
+                    return true;
+                }
+
+                target = null;
+                return false;
+            }
+        }
+
         [Fact]
         public void UserDefinedFunctionsAreCallableInExpressions()
         {
@@ -67,6 +84,15 @@ namespace Serilog.Expressions.Tests.Expressions
             var expr = SerilogExpression.Compile(
                 "SecretWordAt(1) = 'e'",
                 nameResolver: new SecretWordResolver(new StaticMemberNameResolver(typeof(NameResolverTests)), "hello"));
+            Assert.True(Coerce.IsTrue(expr(Some.InformationEvent())));
+        }
+
+        [Fact]
+        public void BuiltInPropertiesCanBeAliased()
+        {
+            var expr = SerilogExpression.Compile(
+                "@Level = 'Information'",
+                nameResolver: new LegacyLevelPropertyNameResolver());
             Assert.True(Coerce.IsTrue(expr(Some.InformationEvent())));
         }
     }


### PR DESCRIPTION
Phew! Sorry that took a while, @warrenbuckley :-) Hope you had a great weekend!

I think you're right about keeping the scope limited. Here's how the `LegacyFilterSyntaxNameResolver` would look, with this change (untested :-)):

```csharp
public class LegacyLevelPropertyNameResolver: NameResolver
{
    public static LogEventPropertyValue? Has(LogEventPropertyValue? value)
    {
        return new ScalarValue(value != null);
    }
    
    public override bool TryResolveFunctionName(string name, [NotNullWhen(true)] out MethodInfo? implementation)
    {
        if ("Has".Equals(name, StringComparison.OrdinalIgnoreCase))
        {
            implementation = GetType().GetMethod("Has", BindingFlags.Static | BindingFlags.Public)!;
            return true;
        }

        implementation = null;
        return false;
    }

    public override bool TryResolveBuiltInPropertyName(string alias, [NotNullWhen(true)] out string? target)
    {
        target = alias switch
        {
            "Exception" => "x",
            "Level" => "l",
            "Message" => "m",
            "MessageTemplate" => "mt",
            "Properties" => "p",
            "Timestamp" => "t",
            _ => null
        };
        
        return target != null;
    }
}
```
