### PR TITLE
3.3.0 Release

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,7 +381,7 @@ User-defined functions are supplied through an instance of `NameResolver`:
 
 ```csharp
 var myFunctions = new StaticMemberNameResolver(typeof(MyFunctions));
-var expr = SerilogExpression.Compile("IsHello(User.Name)", new[] { myFunctions });
+var expr = SerilogExpression.Compile("IsHello(User.Name)", nameResolver: customSerilogFunctions);
 // Filter events based on whether `User.Name` is `'Hello'` :-)
 ```
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Log.Logger = new LoggerConfiguration()
 Templates are based on .NET format strings, and support standard padding, alignment, and format specifiers.
 
 Along with standard properties for the event timestamp (`@t`), level (`@l`) and so on, "holes" in expression templates can include complex
-expressions over the first-class properties of the event, like `{SourceContex}` and `{Cart[0]}` in the example..
+expressions over the first-class properties of the event, like `{SourceContext}` and `{Cart[0]}` in the example..
 
 Templates support customizable color themes when used with the `Console` sink:
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,7 @@ artifacts:
 deploy:
 - provider: NuGet
   api_key:
-    secure: kT0cfI8JdDdk7OBQtaARqgBfJkRGGgyqqHeFcZs1wIyOppSAeiUaF8Syxne/BM7W
+    secure: xIn2Dlahvk1QLaFAazCkjSc83UC1Uv5jeMeyA2NDDiLeHZwFqMm5da6nHEzm6ks5
   skip_symbols: true
   on:
     branch: /^(main|dev)$/

--- a/src/Serilog.Expressions/Expressions/Compilation/Arrays/ConstantArrayEvaluator.cs
+++ b/src/Serilog.Expressions/Expressions/Compilation/Arrays/ConstantArrayEvaluator.cs
@@ -23,7 +23,7 @@ namespace Serilog.Expressions.Compilation.Arrays
     {
         static readonly ConstantArrayEvaluator Instance = new ConstantArrayEvaluator();
 
-        public static Expression Evaluate(Expression expression)
+        public static Expression Rewrite(Expression expression)
         {
             return Instance.Transform(expression);
         }

--- a/src/Serilog.Expressions/Expressions/Compilation/ExpressionCompiler.cs
+++ b/src/Serilog.Expressions/Expressions/Compilation/ExpressionCompiler.cs
@@ -32,13 +32,12 @@ namespace Serilog.Expressions.Compilation
             actual = TextMatchingTransformer.Rewrite(actual);
             actual = LikeSyntaxTransformer.Rewrite(actual);
             actual = PropertiesObjectAccessorTransformer.Rewrite(actual);
-            actual = ConstantArrayEvaluator.Evaluate(actual);
-            actual = WildcardComprehensionTransformer.Expand(actual);
+            actual = ConstantArrayEvaluator.Rewrite(actual);
+            actual = WildcardComprehensionTransformer.Rewrite(actual);
             return actual;
         }
 
-        public static Evaluatable Compile(Expression expression, IFormatProvider? formatProvider,
-            NameResolver nameResolver)
+        public static Evaluatable Compile(Expression expression, IFormatProvider? formatProvider, NameResolver nameResolver)
         {
             var actual = Translate(expression);
             return LinqExpressionCompiler.Compile(actual, formatProvider, nameResolver);

--- a/src/Serilog.Expressions/Expressions/Compilation/Linq/LinqExpressionCompiler.cs
+++ b/src/Serilog.Expressions/Expressions/Compilation/Linq/LinqExpressionCompiler.cs
@@ -218,6 +218,8 @@ namespace Serilog.Expressions.Compilation.Linq
                     BuiltInProperty.Renderings => Splice(context => Intrinsics.GetRenderings(context.LogEvent, formatProvider)),
                     BuiltInProperty.EventId => Splice(context =>
                         new ScalarValue(EventIdHash.Compute(context.LogEvent.MessageTemplate.Text))),
+                    var alias when _nameResolver.TryResolveBuiltInPropertyName(alias, out var target) =>
+                        Transform(new AmbientNameExpression(target, true)),
                     _ => LX.Constant(null, typeof(LogEventPropertyValue))
                 };
             }

--- a/src/Serilog.Expressions/Expressions/Compilation/OrderedNameResolver.cs
+++ b/src/Serilog.Expressions/Expressions/Compilation/OrderedNameResolver.cs
@@ -51,5 +51,17 @@ namespace Serilog.Expressions.Compilation
             boundValue = null;
             return false;
         }
+
+        public override bool TryResolveBuiltInPropertyName(string alias, [NotNullWhen(true)] out string? target)
+        {
+            foreach (var resolver in _orderedResolvers)
+            {
+                if (resolver.TryResolveBuiltInPropertyName(alias, out target))
+                    return true;
+            }
+
+            target = null;
+            return false;
+        }
     }
 }

--- a/src/Serilog.Expressions/Expressions/Compilation/Wildcards/WildcardComprehensionTransformer.cs
+++ b/src/Serilog.Expressions/Expressions/Compilation/Wildcards/WildcardComprehensionTransformer.cs
@@ -22,7 +22,7 @@ namespace Serilog.Expressions.Compilation.Wildcards
     {
         int _nextParameter;
 
-        public static Expression Expand(Expression root)
+        public static Expression Rewrite(Expression root)
         {
             var wc = new WildcardComprehensionTransformer();
             return wc.Transform(root);

--- a/src/Serilog.Expressions/Expressions/NameResolver.cs
+++ b/src/Serilog.Expressions/Expressions/NameResolver.cs
@@ -53,5 +53,20 @@ namespace Serilog.Expressions
             boundValue = null;
             return false;
         }
+
+        /// <summary>
+        /// Map an unrecognized built-in property name to a recognised one.
+        /// </summary>
+        /// <remarks>Intended predominantly to support migration from <em>Serilog.Filters.Expressions</em>.</remarks>
+        /// <param name="alias">The unrecognized name, for example, <code>"Message"</code>; the <code>@</code> prefix is
+        /// not included.</param>
+        /// <param name="target">If the name could be resolved, the target property name, without any prefix; for
+        /// example, <code>"m"</code>.</param>
+        /// <returns>True if the alias was mapped to a built-in property; otherwise, false.</returns>
+        public virtual bool TryResolveBuiltInPropertyName(string alias, [NotNullWhen(true)] out string? target)
+        {
+            target = null;
+            return false;
+        }
     }
 }

--- a/src/Serilog.Expressions/Serilog.Expressions.csproj
+++ b/src/Serilog.Expressions/Serilog.Expressions.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>An embeddable mini-language for filtering, enriching, and formatting Serilog
       events, ideal for use with JSON or XML configuration.</Description>
-    <VersionPrefix>3.2.2</VersionPrefix>
+    <VersionPrefix>3.3.0</VersionPrefix>
     <Authors>Serilog Contributors</Authors>
     <TargetFrameworks>netstandard2.0;netstandard2.1;net5.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Serilog.Expressions/Serilog.Expressions.csproj
+++ b/src/Serilog.Expressions/Serilog.Expressions.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>An embeddable mini-language for filtering, enriching, and formatting Serilog
       events, ideal for use with JSON or XML configuration.</Description>
-    <VersionPrefix>3.2.1</VersionPrefix>
+    <VersionPrefix>3.2.2</VersionPrefix>
     <Authors>Serilog Contributors</Authors>
     <TargetFrameworks>netstandard2.0;netstandard2.1;net5.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/test/Serilog.Expressions.Tests/Expressions/NameResolverTests.cs
+++ b/test/Serilog.Expressions.Tests/Expressions/NameResolverTests.cs
@@ -9,6 +9,7 @@ namespace Serilog.Expressions.Tests.Expressions
 {
     public class NameResolverTests
     {
+        // ReSharper disable once UnusedMember.Global
         public static LogEventPropertyValue? Magic(LogEventPropertyValue? number)
         {
             if (!Coerce.Numeric(number, out var num))
@@ -17,6 +18,7 @@ namespace Serilog.Expressions.Tests.Expressions
             return new ScalarValue(num + 42);
         }
 
+        // ReSharper disable once UnusedMember.Global
         public static LogEventPropertyValue? SecretWordAt(string word, LogEventPropertyValue? index)
         {
             if (!Coerce.Numeric(index, out var i))
@@ -52,6 +54,21 @@ namespace Serilog.Expressions.Tests.Expressions
             }
         }
 
+        class LegacyLevelPropertyNameResolver: NameResolver
+        {
+            public override bool TryResolveBuiltInPropertyName(string alias, [NotNullWhen(true)] out string? target)
+            {
+                if (alias == "Level")
+                {
+                    target = "l";
+                    return true;
+                }
+
+                target = null;
+                return false;
+            }
+        }
+
         [Fact]
         public void UserDefinedFunctionsAreCallableInExpressions()
         {
@@ -67,6 +84,15 @@ namespace Serilog.Expressions.Tests.Expressions
             var expr = SerilogExpression.Compile(
                 "SecretWordAt(1) = 'e'",
                 nameResolver: new SecretWordResolver(new StaticMemberNameResolver(typeof(NameResolverTests)), "hello"));
+            Assert.True(Coerce.IsTrue(expr(Some.InformationEvent())));
+        }
+
+        [Fact]
+        public void BuiltInPropertiesCanBeAliased()
+        {
+            var expr = SerilogExpression.Compile(
+                "@Level = 'Information'",
+                nameResolver: new LegacyLevelPropertyNameResolver());
             Assert.True(Coerce.IsTrue(expr(Some.InformationEvent())));
         }
     }


### PR DESCRIPTION
 * #62 - README update, fix custom name resolver example (@warrenbuckley)
 * #67 - support aliasing of built in property names, to ease migration from _Serilog.Filters.Expressions_ (@nblumhardt)
