### PR TITLE
Add support for for formatting short level names via `ToString()`

### DIFF
--- a/src/Serilog.Expressions/Expressions/Runtime/RuntimeOperators.cs
+++ b/src/Serilog.Expressions/Expressions/Runtime/RuntimeOperators.cs
@@ -17,6 +17,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Serilog.Events;
 using Serilog.Expressions.Compilation.Linq;
+using Serilog.Templates.Rendering;
 
 // ReSharper disable ForCanBeConvertedToForeach, InvertIf, MemberCanBePrivate.Global, UnusedMember.Global, InconsistentNaming, ReturnTypeCanBeNotNullable
 
@@ -501,15 +502,12 @@ namespace Serilog.Expressions.Runtime
                 return null;
             }
 
-            string? toString;
-            if (sv.Value is IFormattable formattable)
+            var toString = sv.Value switch
             {
-                toString = formattable.ToString(fmt, formatProvider);
-            }
-            else
-            {
-                toString = sv.Value.ToString();
-            }
+                LogEventLevel level => LevelRenderer.GetLevelMoniker(level, fmt),
+                IFormattable formattable => formattable.ToString(fmt, formatProvider),
+                _ => sv.Value.ToString()
+            };
 
             return new ScalarValue(toString);
         }

--- a/test/Serilog.Expressions.Tests/Cases/template-evaluation-cases.asv
+++ b/test/Serilog.Expressions.Tests/Cases/template-evaluation-cases.asv
@@ -1,6 +1,7 @@
 Hello, {'world'}!                        ⇶ Hello, world!
 {@l}                                     ⇶ Information
 {@l:u3}                                  ⇶ INF
+{ {level: ToString(@l, 'u3')} }          ⇶ {"level":"INF"}
 Items are {[1, 2]}                       ⇶ Items are [1,2]
 Members are { {a: 1, 'b c': 2} }         ⇶ Members are {"a":1,"b c":2}
 {@p}                                     ⇶ {"Name":"nblumhardt"}


### PR DESCRIPTION
Fixes #69 

This makes the format specifiers accepted for levels consistent between the template syntax `{@l:u3}` and function-call syntax `{ToString(@l, 'u3')}`.
