### PR TITLE
Add a recipie for checking if an object is empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,12 @@ Substring(SourceContext, LastIndexOf(SourceContext, '.') + 1)
 
 This expression takes advantage of `LastIndexOf()` returning -1 when no `.` character appears in `SourceContext`, to yield a `startIndex` of 0 in that case.
 
+**Write not-referenced context properties, only if there any:**
+
+```
+{#if rest(true) <> {}} <Context: {rest(true)}>{#end}
+```
+
 **Access a property with a non-identifier name:**
 
 ```


### PR DESCRIPTION
It took me quite a while to figure out how to conditionally check if the `rest(true)` object was empty, so here it is:

![image](https://user-images.githubusercontent.com/570470/191961877-dfcf5ba1-14c6-4cbe-806e-4ffe7f16f3c5.png)
