### PR TITLE
Output encoding

### DIFF
--- a/example/Sample/Sample.csproj
+++ b/example/Sample/Sample.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Serilog.Expressions/Expressions/Compilation/Linq/ExpressionConstantMapper.cs
+++ b/src/Serilog.Expressions/Expressions/Compilation/Linq/ExpressionConstantMapper.cs
@@ -28,9 +28,8 @@ class ExpressionConstantMapper : ExpressionVisitor
 
     protected override Expression VisitConstant(ConstantExpression node)
     {
-        if (node.Value != null &&
-            node.Value is ScalarValue sv &&
-            _mapping.TryGetValue(sv.Value, out var substitute))
+        if (node.Value is ScalarValue { Value: {} sv } &&
+            _mapping.TryGetValue(sv, out var substitute))
             return substitute;
 
         return base.VisitConstant(node);

--- a/src/Serilog.Expressions/Expressions/Compilation/Linq/Intrinsics.cs
+++ b/src/Serilog.Expressions/Expressions/Compilation/Linq/Intrinsics.cs
@@ -55,9 +55,9 @@ static class Intrinsics
     public static LogEventPropertyValue ConstructSequenceValue(List<LogEventPropertyValue?> elements)
     {
         if (elements.Any(el => el == null))
-            return new SequenceValue(elements.Where(el => el != null));
+            return new SequenceValue(elements.Where(el => el != null)!);
 
-        return new SequenceValue(elements);
+        return new SequenceValue(elements!);
     }
 
     public static List<LogEventProperty> CollectStructureProperties(string[] names, LogEventPropertyValue?[] values)

--- a/src/Serilog.Expressions/Serilog.Expressions.csproj
+++ b/src/Serilog.Expressions/Serilog.Expressions.csproj
@@ -5,7 +5,7 @@
       events, ideal for use with JSON or XML configuration.</Description>
     <VersionPrefix>4.0.0</VersionPrefix>
     <Authors>Serilog Contributors</Authors>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;netstandard2.0;net5.0;net6.0;net7.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <RootNamespace>Serilog</RootNamespace>
     <PackageTags>serilog</PackageTags>
@@ -17,13 +17,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Serilog" Version="2.10.0" />
-    <PackageReference Include="Nullable" Version="1.3.0" PrivateAssets="All" />
+    <PackageReference Include="Serilog" Version="3.0.1" />
+    <PackageReference Include="Nullable" Version="1.3.1" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>
     <None Include="..\..\assets\icon.png" Pack="true" Visible="false" PackagePath="" />
   </ItemGroup>
-
-
+  
 </Project>

--- a/src/Serilog.Expressions/Serilog.Expressions.csproj
+++ b/src/Serilog.Expressions/Serilog.Expressions.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>An embeddable mini-language for filtering, enriching, and formatting Serilog
       events, ideal for use with JSON or XML configuration.</Description>
-    <VersionPrefix>3.4.2</VersionPrefix>
+    <VersionPrefix>4.0.0</VersionPrefix>
     <Authors>Serilog Contributors</Authors>
     <TargetFrameworks>netstandard2.0;netstandard2.1;net5.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Serilog.Expressions/Serilog.Expressions.csproj
+++ b/src/Serilog.Expressions/Serilog.Expressions.csproj
@@ -25,4 +25,5 @@
     <None Include="..\..\assets\icon.png" Pack="true" Visible="false" PackagePath="" />
   </ItemGroup>
 
+
 </Project>

--- a/src/Serilog.Expressions/Templates/Compilation/TemplateFunctionNameResolver.cs
+++ b/src/Serilog.Expressions/Templates/Compilation/TemplateFunctionNameResolver.cs
@@ -17,6 +17,7 @@ using Serilog.Expressions.Compilation;
 using Serilog.Expressions.Runtime;
 using Serilog.Templates.Ast;
 using Serilog.Templates.Compilation.UnreferencedProperties;
+using Serilog.Templates.Compilation.Unsafe;
 
 namespace Serilog.Templates.Compilation;
 
@@ -27,7 +28,8 @@ static class TemplateFunctionNameResolver
         var resolvers = new List<NameResolver>
         {
             new StaticMemberNameResolver(typeof(RuntimeOperators)),
-            new UnreferencedPropertiesFunction(template)
+            new UnreferencedPropertiesFunction(template),
+            new UnsafeOutputFunction()
         };
 
         if (additionalNameResolver != null)

--- a/src/Serilog.Expressions/Templates/Compilation/Unsafe/UnsafeOutputFunction.cs
+++ b/src/Serilog.Expressions/Templates/Compilation/Unsafe/UnsafeOutputFunction.cs
@@ -1,0 +1,49 @@
+﻿// Copyright © Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using Serilog.Events;
+using Serilog.Expressions;
+using Serilog.Templates.Encoding;
+
+namespace Serilog.Templates.Compilation.Unsafe;
+
+/// <summary>
+/// Marks an expression in a template as bypassing the output encoding mechanism.
+/// </summary>
+class UnsafeOutputFunction : NameResolver
+{
+    const string FunctionName = "unsafe";
+
+    public override bool TryResolveFunctionName(string name, [MaybeNullWhen(false)] out MethodInfo implementation)
+    {
+        if (name.Equals(FunctionName, StringComparison.OrdinalIgnoreCase))
+        {
+            implementation = typeof(UnsafeOutputFunction).GetMethod(nameof(Implementation),
+                BindingFlags.Static | BindingFlags.Public)!;
+            return true;
+        }
+
+        implementation = null;
+        return false;
+    }
+
+    // By convention, built-in functions accept and return nullable values.
+    // ReSharper disable once ReturnTypeCanBeNotNullable
+    public static LogEventPropertyValue? Implementation(LogEventPropertyValue? inner)
+    {
+        return new ScalarValue(new PreEncodedValue(inner));
+    }
+}

--- a/src/Serilog.Expressions/Templates/Encoding/EncodedCompiledTemplate.cs
+++ b/src/Serilog.Expressions/Templates/Encoding/EncodedCompiledTemplate.cs
@@ -1,0 +1,25 @@
+﻿using Serilog.Expressions;
+using Serilog.Templates.Compilation;
+
+namespace Serilog.Templates.Encoding
+{
+    class EncodedCompiledTemplate : CompiledTemplate
+    {
+        readonly CompiledTemplate _inner;
+        readonly TemplateOutputEncoder _encoder;
+
+        public EncodedCompiledTemplate(CompiledTemplate inner, TemplateOutputEncoder encoder)
+        {
+            _inner = inner;
+            _encoder = encoder;
+        }
+
+        public override void Evaluate(EvaluationContext ctx, TextWriter output)
+        {
+            var buffer = new StringWriter(output.FormatProvider);
+            _inner.Evaluate(ctx, buffer);
+            var encoded = _encoder.Encode(buffer.ToString());
+            output.Write(encoded);
+        }
+    }
+}

--- a/src/Serilog.Expressions/Templates/Encoding/EncodedTemplateFactory.cs
+++ b/src/Serilog.Expressions/Templates/Encoding/EncodedTemplateFactory.cs
@@ -1,0 +1,33 @@
+﻿using Serilog.Expressions;
+using Serilog.Parsing;
+using Serilog.Templates.Compilation;
+using Serilog.Templates.Themes;
+
+namespace Serilog.Templates.Encoding
+{
+    class EncodedTemplateFactory
+    {
+        readonly TemplateOutputEncoder? _encoder;
+
+        public EncodedTemplateFactory(TemplateOutputEncoder? encoder)
+        {
+            _encoder = encoder;
+        }
+        
+        public CompiledTemplate Wrap(CompiledTemplate inner)
+        {
+            if (_encoder == null)
+                return inner;
+
+            return new EncodedCompiledTemplate(inner, _encoder);
+        }
+        
+        public CompiledTemplate MakeCompiledFormattedExpression(Evaluatable expression, string? format, Alignment? alignment, IFormatProvider? formatProvider, TemplateTheme theme)
+        {
+            if (_encoder == null)
+                return new CompiledFormattedExpression(expression, format, alignment, formatProvider, theme);
+            
+            return new EscapableEncodedCompiledFormattedExpression(expression, format, alignment, formatProvider, theme, _encoder);
+        }
+    }
+}

--- a/src/Serilog.Expressions/Templates/Encoding/EscapableEncodedCompiledFormattedExpression.cs
+++ b/src/Serilog.Expressions/Templates/Encoding/EscapableEncodedCompiledFormattedExpression.cs
@@ -1,0 +1,56 @@
+﻿using Serilog.Events;
+using Serilog.Expressions;
+using Serilog.Expressions.Runtime;
+using Serilog.Parsing;
+using Serilog.Templates.Compilation;
+using Serilog.Templates.Themes;
+
+namespace Serilog.Templates.Encoding
+{
+    class EscapableEncodedCompiledFormattedExpression : CompiledTemplate
+    {
+        static int _nextSubstituteLocalNameSuffix;
+        readonly string _substituteLocalName = $"%sub{Interlocked.Increment(ref _nextSubstituteLocalNameSuffix)}";
+        readonly Evaluatable _expression;
+        readonly TemplateOutputEncoder _encoder;
+        readonly CompiledFormattedExpression _inner;
+
+        public EscapableEncodedCompiledFormattedExpression(Evaluatable expression, string? format, Alignment? alignment, IFormatProvider? formatProvider, TemplateTheme theme, TemplateOutputEncoder encoder)
+        {
+            _expression = expression;
+            _encoder = encoder;
+            _inner = new CompiledFormattedExpression(GetSubstituteLocalValue, format, alignment, formatProvider, theme);
+        }
+
+        LogEventPropertyValue? GetSubstituteLocalValue(EvaluationContext context)
+        {
+            return Locals.TryGetValue(context.Locals, _substituteLocalName, out var computed)
+                ? computed
+                : null;
+        }
+
+        public override void Evaluate(EvaluationContext ctx, TextWriter output)
+        {
+            var value = _expression(ctx);
+            
+            if (value is ScalarValue { Value: PreEncodedValue pv })
+            {
+                var rawContext = pv.Inner == null ?
+                    new EvaluationContext(ctx.LogEvent) :
+                    new EvaluationContext(ctx.LogEvent, Locals.Set(ctx.Locals, _substituteLocalName, pv.Inner));
+                _inner.Evaluate(rawContext, output);
+                return;
+            }
+
+            var buffer = new StringWriter(output.FormatProvider);
+            
+            var bufferedContext = value == null
+                ? ctx
+                : new EvaluationContext(ctx.LogEvent, Locals.Set(ctx.Locals, _substituteLocalName, value));
+
+            _inner.Evaluate(bufferedContext, buffer);
+            var encoded = _encoder.Encode(buffer.ToString());
+            output.Write(encoded);
+        }
+    }
+}

--- a/src/Serilog.Expressions/Templates/Encoding/EscapableEncodedCompiledFormattedExpression.cs
+++ b/src/Serilog.Expressions/Templates/Encoding/EscapableEncodedCompiledFormattedExpression.cs
@@ -19,6 +19,10 @@ namespace Serilog.Templates.Encoding
         {
             _expression = expression;
             _encoder = encoder;
+            
+            // `expression` can't be passed through, because it may include calls to the `unsafe()` function (nested in arbitrary subexpressions) that
+            // need to be evaluated first. So, instead, we evaluate `expression` and unwrap the result of `unsafe`, placing the result in a local variable
+            // that the formatting expression we construct here can read from.
             _inner = new CompiledFormattedExpression(GetSubstituteLocalValue, format, alignment, formatProvider, theme);
         }
 

--- a/src/Serilog.Expressions/Templates/Encoding/PreEncodedValue.cs
+++ b/src/Serilog.Expressions/Templates/Encoding/PreEncodedValue.cs
@@ -1,0 +1,21 @@
+﻿using Serilog.Events;
+
+namespace Serilog.Templates.Encoding
+{
+    class PreEncodedValue
+    {
+        public LogEventPropertyValue? Inner { get; }
+
+        public PreEncodedValue(LogEventPropertyValue? inner)
+        {
+            Inner = inner;
+        }
+
+        public override string ToString()
+        {
+            // This code path indicates that the template expects encoding to be performed, but no encoder is
+            // registered (probably a bad situation to be in).
+            throw new InvalidOperationException("No output encoder is registered.");
+        }
+    }
+}

--- a/src/Serilog.Expressions/Templates/Encoding/TemplateOutputEncoder.cs
+++ b/src/Serilog.Expressions/Templates/Encoding/TemplateOutputEncoder.cs
@@ -1,0 +1,15 @@
+﻿namespace Serilog.Templates.Encoding
+{
+    /// <summary>
+    /// An encoder applied to the output substituted into template holes.
+    /// </summary>
+    public abstract class TemplateOutputEncoder
+    {
+        /// <summary>
+        /// Encode <paramref name="value" />.
+        /// </summary>
+        /// <param name="value">The raw template output to encode.</param>
+        /// <returns>The encoded output.</returns>
+        public abstract string Encode(string value);
+    }
+}

--- a/src/Serilog.Expressions/Templates/Themes/ThemedJsonValueFormatter.cs
+++ b/src/Serilog.Expressions/Templates/Themes/ThemedJsonValueFormatter.cs
@@ -150,7 +150,7 @@ class ThemedJsonValueFormatter : LogEventPropertyValueVisitor<TextWriter, int>
                     : _scalar;
 
             using (style.Set(state, ref count))
-                JsonValueFormatter.WriteQuotedJsonString((element.Key.Value ?? "null").ToString(), state);
+                JsonValueFormatter.WriteQuotedJsonString(element.Key.Value?.ToString() ?? "null", state);
 
             using (_tertiary.Set(state, ref count))
                 state.Write(":");
@@ -244,7 +244,7 @@ class ThemedJsonValueFormatter : LogEventPropertyValueVisitor<TextWriter, int>
         }
 
         using (_scalar.Set(output, ref count))
-            JsonValueFormatter.WriteQuotedJsonString(value.ToString(), output);
+            JsonValueFormatter.WriteQuotedJsonString(value.ToString() ?? "", output);
 
         return count;
     }

--- a/test/Serilog.Expressions.PerformanceTests/ComparisonBenchmark.cs
+++ b/test/Serilog.Expressions.PerformanceTests/ComparisonBenchmark.cs
@@ -23,7 +23,7 @@ public class ComparisonBenchmark
         {
             if (evt.Properties.TryGetValue("A", out var a) && (a as ScalarValue)?.Value is int)
             {
-                return (int)((ScalarValue)a).Value == 3;
+                return (int)((ScalarValue)a).Value! == 3;
             }
 
             return false;

--- a/test/Serilog.Expressions.PerformanceTests/Serilog.Expressions.PerformanceTests.csproj
+++ b/test/Serilog.Expressions.PerformanceTests/Serilog.Expressions.PerformanceTests.csproj
@@ -1,15 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="BenchmarkDotNet" Version="0.10.14" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.7" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Serilog.Expressions.PerformanceTests/Support/Some.cs
+++ b/test/Serilog.Expressions.PerformanceTests/Support/Some.cs
@@ -19,7 +19,7 @@ static class Some
     {
         var log = new LoggerConfiguration().CreateLogger();
 #pragma warning disable Serilog004 // Constant MessageTemplate verifier
-        if (!log.BindMessageTemplate(messageTemplate, propertyValues, out var template, out IEnumerable<LogEventProperty> properties))
+        if (!log.BindMessageTemplate(messageTemplate, propertyValues, out var template, out var properties))
 #pragma warning restore Serilog004 // Constant MessageTemplate verifier
         {
             throw new XunitException("Template could not be bound.");

--- a/test/Serilog.Expressions.Tests/Cases/template-encoding-cases.asv
+++ b/test/Serilog.Expressions.Tests/Cases/template-encoding-cases.asv
@@ -1,0 +1,8 @@
+{@m}                              ⇶ (Hello, nblumhardt!)
+{'world'}!                        ⇶ (world)!
+{unsafe('world')}!                ⇶ world!
+{substring('world', 0, 2)}!       ⇶ (wo)!
+|{somethingnothere}|              ⇶ |()|
+{#if true}x{'A'}x{#end}           ⇶ x(A)x
+{#each a in [1,2,3]}<{a}>{#delimit},{#end}           ⇶ <(1)>,<(2)>,<(3)>
+{ {name: 'world' } }!             ⇶ ({"name":"world"})!

--- a/test/Serilog.Expressions.Tests/Serilog.Expressions.Tests.csproj
+++ b/test/Serilog.Expressions.Tests/Serilog.Expressions.Tests.csproj
@@ -4,9 +4,12 @@
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
-    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="xunit" Version="2.5.0" />
     <PackageReference Include="Serilog.Formatting.Compact" Version="1.1.0" />
   </ItemGroup>
   <ItemGroup>

--- a/test/Serilog.Expressions.Tests/Support/ParenthesizingEncoder.cs
+++ b/test/Serilog.Expressions.Tests/Support/ParenthesizingEncoder.cs
@@ -1,0 +1,11 @@
+﻿using Serilog.Templates.Encoding;
+
+namespace Serilog.Expressions.Tests.Support;
+
+public class ParenthesizingEncoder : TemplateOutputEncoder
+{
+    public override string Encode(string value)
+    {
+        return $"({value})";
+    }
+}

--- a/test/Serilog.Expressions.Tests/Support/Some.cs
+++ b/test/Serilog.Expressions.Tests/Support/Some.cs
@@ -19,7 +19,7 @@ static class Some
     {
         var log = new LoggerConfiguration().CreateLogger();
 #pragma warning disable Serilog004 // Constant MessageTemplate verifier
-        if (!log.BindMessageTemplate(messageTemplate, propertyValues, out var template, out IEnumerable<LogEventProperty> properties))
+        if (!log.BindMessageTemplate(messageTemplate, propertyValues, out var template, out var properties))
 #pragma warning restore Serilog004 // Constant MessageTemplate verifier
         {
             throw new XunitException("Template could not be bound.");

--- a/test/Serilog.Expressions.Tests/Support/StringHashPrefixingTheme.cs
+++ b/test/Serilog.Expressions.Tests/Support/StringHashPrefixingTheme.cs
@@ -1,0 +1,11 @@
+using Serilog.Templates.Themes;
+
+namespace Serilog.Expressions.Tests.Support;
+
+static class StringHashPrefixingTheme
+{
+    public static readonly TemplateTheme Instance = new(new Dictionary<TemplateThemeStyle, string>
+    {
+        [TemplateThemeStyle.String] = "#"
+    });
+}

--- a/test/Serilog.Expressions.Tests/TemplateEncodingTests.cs
+++ b/test/Serilog.Expressions.Tests/TemplateEncodingTests.cs
@@ -1,0 +1,42 @@
+using Serilog.Expressions.Tests.Support;
+using Serilog.Templates;
+using Xunit;
+
+namespace Serilog.Expressions.Tests;
+
+public class TemplateEncodingTests
+{
+    public static IEnumerable<object[]> TemplateEvaluationCases =>
+        AsvCases.ReadCases("template-encoding-cases.asv");
+
+    [Theory]
+    [MemberData(nameof(TemplateEvaluationCases))]
+    public void TemplatesAreCorrectlyEvaluated(string template, string expected)
+    {
+        var evt = Some.InformationEvent("Hello, {Name}!", "nblumhardt");
+        var compiled = new ExpressionTemplate(template, encoder: new ParenthesizingEncoder());
+        var output = new StringWriter();
+        compiled.Format(evt, output);
+        var actual = output.ToString();
+        Assert.Equal(expected, actual);
+    }
+
+    // Either theme or encoding must be applied first; although it's possible to imagine future scenarios (themes as HTML elements with styles...) that
+    // might combine these both in a more sophisticated way, the current implementation chooses to wrap the entire output in the encoder, instead
+    // of the other way around, because it's much easier to exclude any possibility of missed encoding using this approach.
+    [Fact]
+    public void EncodingAppliesToThemedOutput()
+    {
+        var evt = Some.InformationEvent("Hello, {Name}!", "nblumhardt");
+        
+        var compiled = new ExpressionTemplate("-{@m}-",
+            theme: StringHashPrefixingTheme.Instance,
+            encoder: new ParenthesizingEncoder(),
+            applyThemeWhenOutputIsRedirected: true);
+        
+        var output = new StringWriter();
+        compiled.Format(evt, output);
+        var actual = output.ToString();
+        Assert.Equal("-(Hello, #nblumhardt\x1b[0m!)-", actual);
+    }
+}

--- a/test/Serilog.Expressions.Tests/TemplateParserTests.cs
+++ b/test/Serilog.Expressions.Tests/TemplateParserTests.cs
@@ -19,7 +19,7 @@ public class TemplateParserTests
     [InlineData("Empty {Align,} digits", "Syntax error (line 1, column 14): unexpected `}`, expected alignment and width.")]
     public void ErrorsAreReported(string input, string error)
     {
-        Assert.False(ExpressionTemplate.TryParse(input, null, null, null, false, out _, out var actual));
+        Assert.False(ExpressionTemplate.TryParse(input, null, null, null, false, null, out _, out var actual));
         Assert.Equal(error, actual);
     }
 


### PR DESCRIPTION
For `ExpressionTemplate` to be useful in scenarios like HTML email, webhook URL, or URL-encoded `POST` body construction, a safer mechanism is needed for output encoding.

For example, imagine we rewrite _Serilog.Sinks.Email_ to use `ExpressionTemplate`, a message body might look like:

```html
<p class="error">Exception: {@x}</p>
```

Since the email is being fed exceptions from a running application, a malicious user might cause an error to be generated with HTML in the message:

```
System.InvalidOperationException: <a href="my-bad-site">Click to see more info</a><br><br><br>is not a valid username.
    at ...
```

Today, to defend against this an `htmlencode` user-defined function might be used:

```html
<p class="exception">Exception: {htmlencode(@x)}</p>
```

But, we all know how easily opt-in security measures can be overlooked.

This PR proposes to introduce a new type, `TemplateOutputEncoder`, that users (i.e. the _Serilog.Sinks.Email_ assembly) can implement in order to automatically escape all output that's substituted into template holes. For example:

```csharp
class TemplateOutputHtmlEncoder: TemplateOutputEncoder
{
    /// <summary>
    /// Replaces <c>&</c>, <c>&lt;</c>, <c>&gt;</c>, <c>&quot;</c>, and
    /// <c>&apos;</c> with their equivalent escape sequences. This renders the result safe for
    /// insertion into HTML attributes and element bodies apart from <c>script</c> and <c>style</c>.
    /// </summary>
    /// <param name="value">The string to encode.</param>
    /// <returns>The encoded string.</returns>
    public override string Encode(string value)
    {
        return System.Text.Encodings.Web.HtmlEncoder.Default.Encode(value);
    }
}
```

The encoder is provided when parsing/compiling the template:

```csharp
var template = new ExpressionTemplate(
    "<p class="error">Exception: {@x}</p>",
    encoder: new TemplateOutputHtmlEncoder());
```

### Opting out of encoding

The proposal introduces a new function in templates called `unsafe`, which can be used to opt out of escaping:

```html
<p{unsafe(if @l = 'Error' then ' class="error"' else '')}>Exception: {@x}</p>
```

### Caveats

Note that basic HTML escaping as used in the example can't correctly/safely encode values that appear in `style` or `script` contexts. HTML is a familiar use case for the example, but it's not discussed in full here.

### Related work

The feature is based on the fork we use in Seq's webhook plug-in, which uses it for URI encoding within webhook URLs: https://github.com/datalust/seq-app-httprequest#configuration (see the URL row in the linked table).