### PR TITLE
Bind template locals appearing in repetition enumerable expressions

### DIFF
--- a/src/Serilog.Expressions/Templates/Compilation/NameResolution/TemplateLocalNameBinder.cs
+++ b/src/Serilog.Expressions/Templates/Compilation/NameResolution/TemplateLocalNameBinder.cs
@@ -76,7 +76,7 @@ class TemplateLocalNameBinder
             locals.Pop();
 
         return new Repetition(
-            rep.Enumerable,
+            ExpressionLocalNameBinder.BindLocalValueNames(rep.Enumerable, locals),
             rep.BindingNames,
             body,
             rep.Delimiter != null ? Transform(rep.Delimiter, locals) : null,

--- a/test/Serilog.Expressions.Tests/Cases/template-evaluation-cases.asv
+++ b/test/Serilog.Expressions.Tests/Cases/template-evaluation-cases.asv
@@ -25,6 +25,7 @@ A{#if false}B{#else if true}C{#end}                  ⇶ AC
 {#each a in [1,2,3]}<{a}>{#delimit},{#end}           ⇶ <1>,<2>,<3>
 {#each a in {x: 1, y: 2}}{a}{#end}                   ⇶ xy
 {#each a, b in {x: 1, y: 2}}{a}.{b}{#end}            ⇶ x.1y.2
+{#each a, b in {x: {y: 'z'}}}{#each c, d in b}A: {a}, C: {c}, D: {d}{#end}{#end} ⇶ A: x, C: y, D: z
 {#if true}A{#each a in [1]}B{a}{#end}C{#end}D        ⇶ AB1CD
 {#each a in []}{a}!{#else}none{#end}                 ⇶ none
 Culture-specific {42.34}                             ⇶ Culture-specific 42,34


### PR DESCRIPTION
Fix a bug whereby names bound in repetition expressions can't be used in the enumerable argument to nested repetition expressions. (The test hopefully says it all 😅 .)