### PR TITLE
Supply the list element index in the second #each parameter when enumerating

### DIFF
--- a/test/Serilog.Expressions.Tests/Cases/template-evaluation-cases.asv
+++ b/test/Serilog.Expressions.Tests/Cases/template-evaluation-cases.asv
@@ -23,6 +23,7 @@ A{#if false}B{#else if false}C{#else if true}D{#else}E{#end} ⇶ AD
 A{#if false}B{#else if true}C{#end}                  ⇶ AC
 {#if true}A{#if false}B{#else}C{#end}D{#end}         ⇶ ACD
 {#each a in [1,2,3]}<{a}>{#delimit},{#end}           ⇶ <1>,<2>,<3>
+{#each a, i in [1,2,3]}<{a}>({i}){#delimit},{#end}   ⇶ <1>(0),<2>(1),<3>(2)
 {#each a in {x: 1, y: 2}}{a}{#end}                   ⇶ xy
 {#each a, b in {x: 1, y: 2}}{a}.{b}{#end}            ⇶ x.1y.2
 {#if true}A{#each a in [1]}B{a}{#end}C{#end}D        ⇶ AB1CD


### PR DESCRIPTION
This is useful when conditionally formatting the first or last element in a list, or when generating unique identifiers for each element - for example, when formatting HTML tables.

```
{#each e, i in ['a', 'b', 'c']}
  Element: {e}
  Index: {i}
{#end}
```

produces:

```
  Element: a
  Index: 0

  Element: b
  Index: 1

  Element: c
  Index: 2
```
