### PR TITLE
Accessors such as `a.B` should be case-sensitive

### DIFF
--- a/src/Serilog.Expressions/Expressions/Compilation/Linq/LinqExpressionCompiler.cs
+++ b/src/Serilog.Expressions/Expressions/Compilation/Linq/LinqExpressionCompiler.cs
@@ -186,9 +186,8 @@ class LinqExpressionCompiler : SerilogExpressionTransformer<ExpressionBody>
     protected override ExpressionBody Transform(AccessorExpression spx)
     {
         var receiver = Transform(spx.Receiver);
-        return LX.Call(TryGetStructurePropertyValueMethod, LX.Constant(StringComparison.OrdinalIgnoreCase), receiver, LX.Constant(spx.MemberName, typeof(string)));
+        return LX.Call(TryGetStructurePropertyValueMethod, LX.Constant(StringComparison.Ordinal), receiver, LX.Constant(spx.MemberName, typeof(string)));
     }
-
     protected override ExpressionBody Transform(ConstantExpression cx)
     {
         return LX.Constant(cx.Constant);

--- a/test/Serilog.Expressions.Tests/Cases/expression-evaluation-cases.asv
+++ b/test/Serilog.Expressions.Tests/Cases/expression-evaluation-cases.asv
@@ -24,6 +24,12 @@ false                                ⇶ false
 {a: 1, ..{b: 2}, b: undefined()}     ⇶ {a: 1}
 {a: 1, ..{a: undefined()}}           ⇶ {a: 1}
 {..{a: 1}, ..{b: 2, c: 3}}           ⇶ {a: 1, b: 2, c: 3}
+{a: 1}['a']                          ⇶ 1
+{a: 1}['A']                          ⇶ undefined()
+{a: 1}.a                             ⇶ 1
+{a: 1}.A                             ⇶ undefined()
+ElementAt({a: 1}, 'A')               ⇶ undefined()
+ElementAt({a: 1}, 'A') ci            ⇶ 1
 
 // Strings
 ''                                   ⇶ ''


### PR DESCRIPTION
This is a bugfix, but needs to be in a new major because it's also a breaking change.

`ElementAt(a, b) ci` plays the role of a case-insensitive accessor.