### PR TITLE
Make the `rest()` function aware of `@p.X` and `@p['X']` (breaking change)

### DIFF
--- a/src/Serilog.Expressions/Serilog.Expressions.csproj
+++ b/src/Serilog.Expressions/Serilog.Expressions.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>An embeddable mini-language for filtering, enriching, and formatting Serilog
       events, ideal for use with JSON or XML configuration.</Description>
-    <VersionPrefix>4.0.1</VersionPrefix>
+    <VersionPrefix>5.0.0</VersionPrefix>
     <Authors>Serilog Contributors</Authors>
     <TargetFrameworks>netstandard2.1;netstandard2.0;net5.0;net6.0;net7.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/test/Serilog.Expressions.Tests/Templates/UnreferencedPropertiesFunctionTests.cs
+++ b/test/Serilog.Expressions.Tests/Templates/UnreferencedPropertiesFunctionTests.cs
@@ -19,32 +19,34 @@ public class UnreferencedPropertiesFunctionTests
     [Fact]
     public void UnreferencedPropertiesExcludeThoseInMessageAndTemplate()
     {
-        Assert.True(new TemplateParser().TryParse("{@m}{A + 1}{#if true}{B}{#end}", out var template, out _));
+        Assert.True(new TemplateParser().TryParse("{@m}{A + 1}{#if true}{B}{@p.C}{@p['D']}{#end}", out var template, out _));
 
-        var function = new UnreferencedPropertiesFunction(template!);
+        var function = new UnreferencedPropertiesFunction(template);
 
         var evt = new LogEvent(
             DateTimeOffset.Now,
             LogEventLevel.Debug,
             null,
-            new(new[] {new PropertyToken("C", "{C}")}),
+            new(new[] {new PropertyToken("E", "{E}")}),
             new[]
             {
                 new LogEventProperty("A", new ScalarValue(null)),
                 new LogEventProperty("B", new ScalarValue(null)),
                 new LogEventProperty("C", new ScalarValue(null)),
                 new LogEventProperty("D", new ScalarValue(null)),
+                new LogEventProperty("E", new ScalarValue(null)),
+                new LogEventProperty("F", new ScalarValue(null)),
             });
 
         var deep = UnreferencedPropertiesFunction.Implementation(function, evt, new ScalarValue(true));
 
         var sv = Assert.IsType<StructureValue>(deep);
         var included = Assert.Single(sv.Properties);
-        Assert.Equal("D", included!.Name);
+        Assert.Equal("F", included.Name);
 
         var shallow = UnreferencedPropertiesFunction.Implementation(function, evt);
         sv = Assert.IsType<StructureValue>(shallow);
-        Assert.Contains(sv.Properties, p => p.Name == "C");
-        Assert.Contains(sv.Properties, p => p.Name == "D");
+        Assert.Contains(sv.Properties, p => p.Name == "E");
+        Assert.Contains(sv.Properties, p => p.Name == "F");
     }
 }


### PR DESCRIPTION
Fixes #107

The existing behavior was intended to allow `@p.X` to be an escape hatch so that the reference to `X` is invisible to `rest()`. This turns out to be confusing in actual use.

The new ways to hide a property reference from `rest()` are:

```
let p = @p in p.X
```

or

```
@p[concat('X', '')]
```

etc.

Major version bump because this is likely to affect a few templates in use.