### PR TITLE
Upgraded Serilog version

### DIFF
--- a/src/Serilog.Expressions/Serilog.Expressions.csproj
+++ b/src/Serilog.Expressions/Serilog.Expressions.csproj
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Serilog" Version="3.1.0" />
+    <PackageReference Include="Serilog" Version="3.1.1" />
     <PackageReference Include="Nullable" Version="1.3.1" PrivateAssets="All" />
   </ItemGroup>
 


### PR DESCRIPTION
Serilog version 3.1.0 causes stackoverflowException. https://github.com/serilog/serilog/pull/1977