### PR TITLE
Handle Exception.ToString() failures in template compilation

### DIFF
--- a/src/Serilog.Expressions/Templates/Compilation/CompiledExceptionToken.cs
+++ b/src/Serilog.Expressions/Templates/Compilation/CompiledExceptionToken.cs
@@ -36,7 +36,17 @@ class CompiledExceptionToken : CompiledTemplate
         if (ctx.LogEvent.Exception is null)
             return;
 
-        var lines = new StringReader(ctx.LogEvent.Exception.ToString());
+        StringReader lines;
+        try
+        {
+            lines = new StringReader(ctx.LogEvent.Exception.ToString());
+        }
+        catch (Exception e)
+        {
+            lines = new StringReader(
+                $"[Exception.ToString() failed: {e.Message}] Original exception type: {ctx.LogEvent.Exception?.GetType().FullName}, message: {ctx.LogEvent.Exception?.Message}{Environment.NewLine}");
+        }
+
         while (lines.ReadLine() is { } nextLine)
         {
             var style = nextLine.StartsWith(StackFrameLinePrefix) ? _secondaryText : _text;


### PR DESCRIPTION
Closes #134 .
Wrap Exception.ToString() in a try-catch block to handle potential failures. If an exception occurs, output a fallback message with details about the original exception and the error encountered.